### PR TITLE
Selectively force ssh for git clone

### DIFF
--- a/git/gitconfig-common.symlink
+++ b/git/gitconfig-common.symlink
@@ -3,6 +3,11 @@
 	email = clayton@oneill.net
 	signingKey = clayton@oneill.net
 
+[url "git@github.com:claytono"]
+        insteadOf = https://github.com/claytono
+[url "git@github.com:github"]
+        insteadOf = https://github.com/github
+
 [color]
 	diff = auto
 	status = auto

--- a/git/gitconfig.linux.symlink
+++ b/git/gitconfig.linux.symlink
@@ -1,6 +1,2 @@
-[credential]
-        helper = osxkeychain
-        [url "git@github.com:"]
-                insteadOf = https://github.com/
 [include]
   path = ~/.gitconfig-common

--- a/git/gitconfig.macos.symlink
+++ b/git/gitconfig.macos.symlink
@@ -3,8 +3,6 @@
 
 [credential]
 	helper = osxkeychain
-[url "git@github.com:"]
-	insteadOf = https://github.com/
 
 [include]
   path = ~/.gitconfig-common


### PR DESCRIPTION
Only force ssh for git clones for my account and the github org, since
those are the only private repos I commonly access.  This allows cloning
public repos over https where it doesn't matter.