### PR TITLE
Migrate to home-manager and modernize shell config

### DIFF
--- a/.bash_profile
+++ b/.bash_profile
@@ -3,8 +3,6 @@
 # OS variables
 [ "$(uname -s)" = "Darwin" ] && export MACOS=1 && export UNIX=1
 [ "$(uname -s)" = "Linux" ] && export LINUX=1 && export UNIX=1
-uname -s | grep -q "_NT-" && export WINDOWS=1
-grep -q "Microsoft" /proc/version 2>/dev/null && export UBUNTU_ON_WINDOWS=1
 
 command_exists () {
     type "$1" &> /dev/null ;
@@ -20,13 +18,14 @@ pathmunge () {
         fi
 }
 
-AIRPORTCMD="/System/Library/PrivateFrameworks/Apple80211.framework/Versions/A/Resources/airport"
-if [ -x $AIRPORTCMD ]; then
-  alias airport=$AIRPORTCMD
-fi
+move_to_front() {
+    local dir="$1"
+    # Remove the directory from the PATH if it exists
+    PATH=$(echo "$PATH" | awk -v RS=: -v ORS=: '$0 != "'"$dir"'"' | sed 's/:$//')
+    # Add the directory to the front of the PATH
+    export PATH="$dir:$PATH"
+}
 
-export GOPATH=$HOME/src/go
-pathmunge $GOPATH/bin
 pathmunge /usr/local/sbin
 pathmunge $HOME/bin
 
@@ -48,9 +47,14 @@ if [ -d "${HOME}/.krew/bin" ]; then
   pathmunge "${HOME}/.krew/bin" after
 fi
 
+# Check if bash completion is available before sourcing
 if command_exists brew; then
   if [[ -f $(brew --prefix)/etc/bash_completion ]]; then
-    source $(brew --prefix)/etc/bash_completion
+    if command_exists complete; then
+      source $(brew --prefix)/etc/bash_completion
+    else
+      echo "Warning: bash completion not available - 'complete' command not found" >&2
+    fi
   fi
 fi
 
@@ -67,55 +71,36 @@ else
   fi
 fi
 
-if command_exists hub; then
-    alias git=hub
-fi
-
 if command_exists vim; then
     export EDITOR=$(type -p vim)
     export GIT_EDITOR=$EDITOR
 fi
 
-if command_exists rbenv; then
-    eval "$(rbenv init -)"
+# OrbStack: command-line tools and integration
+if [ -f ~/.orbstack/shell/init.bash ]; then
+  source ~/.orbstack/shell/init.bash
 fi
-
-if command_exists pyenv; then
-    export PYENV_ROOT="$HOME/.pyenv"
-    pathmunge "$PYENV_ROOT/bin"
-    eval "$(pyenv init --path)"
-    eval "$(pyenv init -)"
-    eval "$(pyenv virtualenv-init -)"
+# Nix PATH priority - ensure nix binaries come first
+# User profile must be move_to_front'd last so it ends up first in PATH
+if [ -d /nix/var/nix/profiles/default/bin ]; then
+  move_to_front /nix/var/nix/profiles/default/bin
 fi
-
-if command_exists direnv; then
-    eval "$(direnv hook bash)"
+if [ -d ~/.nix-profile/bin ]; then
+  move_to_front ~/.nix-profile/bin
 fi
-
-if command_exists asdf; then
-    . $(brew --prefix asdf)/libexec/asdf.sh
-    . $(brew --prefix asdf)/etc/bash_completion.d/asdf.bash
-fi
-
-if [ -f ~/.netrc ]; then
-    if grep -q goproxy.githubapp.com ~/.netrc; then
-        export GOPROXY=https://goproxy.githubapp.com/mod,https://proxy.golang.org/,direct
-        export GOPRIVATE=
-        export GONOPROXY=
-        export GONOSUMDB='github.com/github/*'
-    fi
-fi
-
-alias "kt=watch kubectl get nodes,pods,cronjobs --all-namespaces -o wide"
-alias "y=yadm"
 
 # check if this is a login and/or interactive shell
-[ "$0" = "-bash" ] && export LOGIN_BASH="1"
-echo "$-" | grep -q "i" && export INTERACTIVE_BASH="1"
+# Use shopt instead of $0 check - works with both -bash and bash -l
+shopt -q login_shell && export LOGIN_BASH="1"
+[[ "$-" == *i* ]] && export INTERACTIVE_BASH="1"
 
 # run bashrc if this is a login, interactive shell
 if [ -n "$LOGIN_BASH" ] && [ -n "$INTERACTIVE_BASH" ]; then
   source ~/.bashrc
 fi
 
-export PATH="$HOME/.cargo/bin:$PATH"
+
+# LM Studio CLI
+if [ -d ~/.lmstudio/bin ]; then
+  pathmunge ~/.lmstudio/bin after
+fi

--- a/.bashrc
+++ b/.bashrc
@@ -1,10 +1,15 @@
 # shellcheck shell=bash
 
 # check if this is a login shell
-[ "$0" = "-bash" ] && export LOGIN_BASH="1"
+# Use shopt instead of $0 check - works with both -bash and bash -l
+shopt -q login_shell && export LOGIN_BASH="1"
 
 # run bash_profile if this is not a login shell
 [ -z "$LOGIN_BASH" ] && source ~/.bash_profile
+
+if [ -n "${GHOSTTY_RESOURCES_DIR}" ] && [ -f "${GHOSTTY_RESOURCES_DIR}/shell-integration/bash/ghostty.bash" ]; then
+  builtin source "${GHOSTTY_RESOURCES_DIR}/shell-integration/bash/ghostty.bash"
+fi
 
 # From: https://github.com/mrzool/bash-sensible/
 # Update window size after every command
@@ -34,30 +39,32 @@ export HISTIGNORE="&:[ ]*:exit:ls:bg:fg:history:clear"
 # Useful timestamp format
 HISTTIMEFORMAT='%F %T '
 
-# pc_ = promptcolor_
+# prompt colors
 pc_lgreen="\[$(tput setaf 10)\]"
 pc_lblue="\[$(tput setaf 12)\]"
 pc_lred="\[$(tput setaf 9)\]"
 pc_reset="\[$(tput sgr0)\]"
 
-p_user() {
-    if [[ $USER != "coneill" && $USER != "claytono " && $USER != "codespace" ]]; then
-      echo "${pc_lred}\u${pc_reset}@"
-    fi
-}
+# inline flake name
+flake_segment='${FLAKE_NAME:+${FLAKE_NAME}❄️}'
 
-p_git_branch() {
-  git branch 2> /dev/null | sed -e '/^[^*]/d' -e 's/* \(.*\)/ (\1)/'
-}
+# inline conditional user (shown if not coneill, claytono, or codespace)
+user_segment='$( [[ $USER != "coneill" && $USER != "claytono" && $USER != "codespace" ]] && echo "'$pc_lred'\u'$pc_reset'@" )'
 
-prompt_command() {
-  PS1="$(p_user)${pc_lgreen}\h${pc_reset}:${pc_lblue}\w${pc_lred}$(p_git_branch)${pc_reset}\$ "
-}
+# inline git branch
+git_branch_segment='$(b=$(git rev-parse --abbrev-ref HEAD 2>/dev/null); [[ -n "$b" ]] && echo "'$pc_lred' ($b)'$pc_reset'")'
+
+# final prompt string
+PS1="$flake_segment$user_segment${pc_lgreen}\h${pc_reset}:${pc_lblue}\w${pc_reset}$git_branch_segment\$ "
 PROMPT_DIRTRIM=3
-PROMPT_COMMAND=prompt_command
+
+alias k='kubecolor'
+
+command -v direnv &>/dev/null && eval "$(direnv hook bash)"
 
 [ -f ~/.fzf.bash ] && source ~/.fzf.bash
 
-if [ -f ~/.ssh/github.id_rsa ]; then
-  ssh-add -q ~/.ssh/github.id_rsa
-fi
+[ -f "$HOME/.cargo/env" ] && . "$HOME/.cargo/env"
+
+[[ -f ~/.bash-preexec.sh ]] && source ~/.bash-preexec.sh
+command -v atuin &>/dev/null && eval "$(atuin init bash --disable-up-arrow)"

--- a/.gitconfig-common
+++ b/.gitconfig-common
@@ -27,14 +27,14 @@
 	decorate = true
         mailmap = true
 
-[hub]
-protocol = https
-
 [github]
 	user = claytono
 [protocol]
 	version = 2
 [push]
-	default = simple
+	default = current
+	autoSetupRemote = true
 [init]
 	defaultBranch = main
+[pull]
+	rebase = true

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 *.swp
 .vscode
 .vagrant
+
+# Beads (JSONL committed only to beads-sync branch)
+.beads/issues.jsonl
+.beads/interactions.jsonl

--- a/.tmux.conf
+++ b/.tmux.conf
@@ -17,7 +17,7 @@ bind -T copy-mode ^d send-keys -X page-down
 set -g default-terminal "screen-256color"
 if-shell '[[ $(uname -s) = Darwin ]]' {
   if-shell '[[ $(uname -m) = arm64 ]]' {
-    set -g default-command "/opt/homebrew/bin/reattach-to-user-namespace -l /opt/homebrew/bin/bash -l"
+    set -g default-command "/opt/homebrew/bin/reattach-to-user-namespace -l /Users/coneill/.nix-profile/bin/bash -l"
   }
   if-shell '[[ $(uname -m) = x86_64 ]]' {
     set -g default-command "/usr/local/bin/reattach-to-user-namespace -l /usr/local/bin/bash -l"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,33 @@
+# Claude Code Instructions
+
+## Repository Structure
+
+This is a dotfiles repository managed by YADM. Files in the root are symlinked to the home directory.
+
+## Nix Flake
+
+CLI packages are managed by home-manager via `home.nix`.
+
+To apply changes after editing `home.nix`:
+```bash
+home-manager switch
+```
+
+To update inputs:
+```bash
+nix flake update
+```
+
+## Testing Changes
+
+Shell config changes can be tested by sourcing:
+```bash
+source ~/.bash_profile
+```
+
+## Conventions
+
+- Nix must be used for CLI tools when available in nixpkgs. Homebrew is only for GUI apps (casks) and tools not in nixpkgs.
+- Shell configs (`.bash_profile`, `.bashrc`) must be idempotent - sourcing multiple times should have no side effects.
+- Keep shell configs compatible with both macOS and Linux.
+- Use defensive checks (e.g., `[ -f file ] && source file`) for optional integrations.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,85 @@
+# Dotfiles
+
+Personal dotfiles managed with [YADM](https://yadm.io/) and [Nix](https://nixos.org/).
+
+## Overview
+
+- **Dotfiles**: Managed by YADM (symlinks files to home directory)
+- **CLI packages**: Managed by home-manager via Nix flake (`home.nix`)
+- **GUI apps**: Managed by Homebrew casks via `.Brewfile`
+
+## Setup
+
+### New Machine
+
+1. Install Nix using the [Determinate Systems installer](https://determinate.systems/nix-installer/):
+   ```bash
+   curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install
+   ```
+
+2. Clone dotfiles with YADM:
+   ```bash
+   nix run nixpkgs#yadm -- clone https://github.com/claytono/dotfiles.git
+   ```
+
+   This will prompt to run bootstrap, which installs Homebrew and runs `brew bundle`.
+
+3. Activate home-manager configuration:
+   ```bash
+   cd ~/src/dotfiles
+   nix run home-manager/master -- switch --flake .
+   ```
+
+   This installs all CLI packages defined in `home.nix` and activates the
+   home-manager configuration. The first run requires `--flake .` but
+   home-manager creates a symlink at `~/.config/home-manager` so subsequent
+   runs can use just `home-manager switch`.
+
+## Nix
+
+### Updating Packages
+
+Update flake inputs and rebuild:
+```bash
+cd ~/src/dotfiles
+nix flake update
+home-manager switch
+```
+
+### Adding New Packages
+
+Edit `home.nix` to add packages, then:
+```bash
+home-manager switch
+```
+
+## Homebrew
+
+GUI apps and some CLI tools are managed via `.Brewfile`.
+
+### Updating Packages
+
+```bash
+brew bundle --global
+```
+
+### Adding New Packages
+
+Edit `.Brewfile` to add packages or casks, then run `brew bundle --global`.
+
+## What's Included
+
+### Shell Configuration
+- `.bash_profile` - PATH setup, shell environment
+- `.bashrc` - Interactive shell config, prompt, aliases
+
+### Git Configuration
+- `.gitconfig` - Machine-specific git config (includes common)
+- `.gitconfig-common` - Shared git settings
+
+### Other
+- `.tmux.conf` - tmux configuration
+- `.vimrc` - vim configuration
+- `.Brewfile` - Homebrew packages and casks
+- `home.nix` - Home-manager package configuration
+- `flake.nix` - Nix flake definition

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,222 @@
+{
+  "nodes": {
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1673956053,
+        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1762980239,
+        "narHash": "sha256-8oNVE8TrD19ulHinjaqONf9QWCKK+w4url56cdStMpM=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "52a2caecc898d0b46b2b905f058ccc5081f842da",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1676283394,
+        "narHash": "sha256-XX2f9c3iySLCw54rJ/CZs+ZK6IQy7GXNY4nSOyu2QG4=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "3db36a8b464d0c4532ba1c7dda728f4576d6d073",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "home-manager": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1766282146,
+        "narHash": "sha256-0V/nKU93KdYGi+5LB/MVo355obBJw/2z9b2xS3bPJxY=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "61fcc9de76b88e55578eb5d79fc80f2b236df707",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "type": "github"
+      }
+    },
+    "nix-filter": {
+      "locked": {
+        "lastModified": 1710156097,
+        "narHash": "sha256-1Wvk8UP7PXdf8bCCaEoMnOT1qe5/Duqgj+rL8sRQsSM=",
+        "owner": "numtide",
+        "repo": "nix-filter",
+        "rev": "3342559a24e85fc164b295c3444e8a139924675b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "nix-filter",
+        "type": "github"
+      }
+    },
+    "nix-search-cli": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "flake-utils": "flake-utils",
+        "nix-filter": "nix-filter",
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1762187737,
+        "narHash": "sha256-NGL9jj4y16+d0Es7aK1oxqAimZn7sdJDAxVkcY3CTcg=",
+        "owner": "peterldowns",
+        "repo": "nix-search-cli",
+        "rev": "ab0d5156c1e3b383c250ff273639cd3dea6de2d9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "peterldowns",
+        "repo": "nix-search-cli",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1761752004,
+        "narHash": "sha256-z83uhYagfW6ZnH5Svvaxx6O0a305sBLGCCJZBJnMD9w=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "ddf56acbeb53825b79b82c13a657806774bfd137",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1761765539,
+        "narHash": "sha256-b0yj6kfvO8ApcSE+QmA6mUfu8IYG6/uU28OFn4PaC8M=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "719359f4562934ae99f5443f20aa06c2ffff91fc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1766125104,
+        "narHash": "sha256-l/YGrEpLromL4viUo5GmFH3K5M1j0Mb9O+LiaeCPWEM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "7d853e518814cca2a657b72eeba67ae20ebf7059",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_3": {
+      "locked": {
+        "lastModified": 1763283776,
+        "narHash": "sha256-Y7TDFPK4GlqrKrivOcsHG8xSGqQx3A6c+i7novT85Uk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "50a96edd8d0db6cc8db57dab6bb6d6ee1f3dc49a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "home-manager": "home-manager",
+        "nix-search-cli": "nix-search-cli",
+        "nixpkgs": "nixpkgs_2",
+        "strace-macos": "strace-macos"
+      }
+    },
+    "strace-macos": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs_3",
+        "treefmt-nix": "treefmt-nix"
+      },
+      "locked": {
+        "lastModified": 1763554738,
+        "narHash": "sha256-z/5yWKTiTXt2GGOHj/94ndyADfPUHNe4i1ECjZ4coLA=",
+        "owner": "Mic92",
+        "repo": "strace-macos",
+        "rev": "8a8cb59de94f2d922df474898a42df17a228f3a6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Mic92",
+        "repo": "strace-macos",
+        "type": "github"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "strace-macos",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1762938485,
+        "narHash": "sha256-AlEObg0syDl+Spi4LsZIBrjw+snSVU4T8MOeuZJUJjM=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "5b4ee75aeefd1e2d5a1cc43cf6ba65eba75e83e4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,30 @@
+{
+  description = "My personal Nix packages";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+
+    home-manager = {
+      url = "github:nix-community/home-manager";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    # Include the nix-search-cli flake
+    nix-search-cli = {
+      url = "github:peterldowns/nix-search-cli";
+    };
+
+    # Include strace-macos
+    strace-macos = {
+      url = "github:Mic92/strace-macos";
+    };
+  };
+
+  outputs = { self, nixpkgs, home-manager, nix-search-cli, strace-macos }: {
+      homeConfigurations."coneill" = home-manager.lib.homeManagerConfiguration {
+        pkgs = nixpkgs.legacyPackages.aarch64-darwin;
+        modules = [ ./home.nix ];
+        extraSpecialArgs = { inherit nix-search-cli strace-macos; };
+      };
+    };
+}

--- a/home.nix
+++ b/home.nix
@@ -1,0 +1,115 @@
+{ config, pkgs, lib, ... }:
+
+let
+  # Custom package to include only the watch binary from procps on macOS
+  watch-only = pkgs.stdenv.mkDerivation {
+    name = "watch-only";
+    unpackPhase = "true";
+    buildPhase = "true";
+    installPhase = ''
+      mkdir -p $out/bin
+      cp ${pkgs.procps}/bin/watch $out/bin/
+    '';
+    meta = with pkgs.lib; {
+      description = "Only the watch binary from procps for macOS";
+      platforms = platforms.darwin;
+    };
+  };
+
+  # Custom package to include only specific binaries from coreutils and findutils
+  coreutils-partial = pkgs.stdenv.mkDerivation {
+    name = "coreutils-partial";
+    unpackPhase = "true";
+    buildPhase = "true";
+    installPhase = ''
+      mkdir -p $out/bin
+      cp ${pkgs.coreutils}/bin/timeout $out/bin/
+      cp ${pkgs.findutils}/bin/find $out/bin/
+    '';
+    meta = with pkgs.lib; {
+      description = "Only timeout from coreutils and find from findutils";
+      platforms = platforms.darwin;
+    };
+  };
+
+  # Custom package to include only the ts binary from moreutils
+  ts-only = pkgs.stdenv.mkDerivation {
+    name = "ts-only";
+    unpackPhase = "true";
+    buildPhase = "true";
+    installPhase = ''
+      mkdir -p $out/bin
+      cp ${pkgs.moreutils}/bin/ts $out/bin/
+    '';
+    meta = with pkgs.lib; {
+      description = "Only the ts binary from moreutils";
+      platforms = platforms.darwin;
+    };
+  };
+
+in {
+  home.username = "coneill";
+  home.homeDirectory = "/Users/coneill";
+  home.stateVersion = "24.05";
+
+  programs.home-manager.enable = true;
+
+  xdg.configFile."home-manager".source = config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/src/dotfiles";
+
+  home.packages = with pkgs; [
+    argocd
+    atool
+    atuin
+    bash
+    bash-completion
+    bun
+    dust
+    cachix
+    codeowners
+    codex
+    curl
+    direnv
+    fd
+    ffmpeg
+    fzf
+    gh
+    git
+    git-crypt
+    kubernetes-helm
+    htop
+    jq
+    k9s
+    kubecolor
+    kubectx
+    kubectl
+    lftp
+    lsd
+    mtr
+    nix-search-cli
+    nmap
+    nodejs_24
+    p7zip
+    patchutils_0_4_2
+    prettyping
+    pstree
+    pv
+    rclone
+    restic
+    ripgrep
+    socat
+    timer
+    tmux
+    todoist
+    uv
+    vim
+    wget
+    xz
+    yadm
+    yq-go
+    yt-dlp
+  ] ++ lib.optionals pkgs.stdenv.isDarwin [
+    watch-only
+    coreutils-partial
+    ts-only
+  ];
+}


### PR DESCRIPTION
## Summary

- Add home-manager via nix flake for declarative package management
- Simplify .bash_profile: add `move_to_front` PATH helper, remove legacy tool init (rbenv/pyenv/asdf/hub), add OrbStack and nix PATH priority
- Simplify .bashrc: add defensive guards for optional integrations (direnv, cargo, atuin, Ghostty), refactor prompt construction
- Update .gitconfig-common: add `pull.rebase`, `push.default=current`, remove invalid `pull.default`, `safe.directory=*`, and LFS filter
- Add `home.nix` with packages and xdg symlink for home-manager config discovery
- Add `flake.nix` and `flake.lock`
- Add `README.md` and `CLAUDE.md` with setup and workflow documentation
- Add `.gitignore` entries for beads JSONL files (committed only to beads-sync branch)