### PR TITLE
Add Dagu job scheduler with weekly cleanup workflows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,13 @@
 .vscode
 .vagrant
 
+# Dagu runtime files
+config/dagu/dags/.dag.index
+config/dagu/dags/docs/
+config/dagu/dags/memory/
+config/dagu/dags/skills/
+config/dagu/dags/souls/
+
 # Beads (JSONL committed only to beads-sync branch)
 .beads/issues.jsonl
 .beads/interactions.jsonl

--- a/config/dagu/dags/cleanup-act.yaml
+++ b/config/dagu/dags/cleanup-act.yaml
@@ -1,0 +1,5 @@
+schedule: "0 5 * * 0"
+steps:
+  - id: clean_cache
+    script: |
+      rm -rf ~/.cache/act/ ~/.cache/actcache/

--- a/config/dagu/dags/cleanup-dagu.yaml
+++ b/config/dagu/dags/cleanup-dagu.yaml
@@ -1,0 +1,9 @@
+schedule: "0 6 * * 0"
+steps:
+  - id: rotate_logs
+    script: |
+      for log in ~/.local/share/dagu/dagu.stdout.log ~/.local/share/dagu/dagu.stderr.log; do
+        if [ -f "$log" ] && [ "$(stat -f%z "$log")" -gt 10485760 ]; then
+          truncate -s 0 "$log"
+        fi
+      done

--- a/config/dagu/dags/cleanup-docker.yaml
+++ b/config/dagu/dags/cleanup-docker.yaml
@@ -1,0 +1,18 @@
+type: graph
+schedule: "0 2 * * 0"
+steps:
+  - id: prune_containers
+    command: docker container prune -f --filter "until=72h"
+
+  - id: prune_dangling_images
+    command: docker image prune -f
+
+  - id: prune_build_cache
+    command: docker builder prune -f --filter "until=168h"
+
+  - id: prune_networks
+    command: docker network prune -f
+
+  - id: prune_old_images
+    depends: [prune_containers]
+    command: docker image prune -a -f --filter "until=720h"

--- a/config/dagu/dags/cleanup-nix.yaml
+++ b/config/dagu/dags/cleanup-nix.yaml
@@ -1,0 +1,21 @@
+schedule: "0 1 * * 0"
+steps:
+  - id: prune_eval_cache
+    script: |
+      find ~/.cache/nix/eval-cache-v*/ -type f -mtime +30 -delete 2>/dev/null || true
+
+  - id: prune_tarball_cache
+    script: |
+      if [ -d ~/.cache/nix/tarball-cache ]; then
+        cd ~/.cache/nix/tarball-cache && git gc --prune=30.days.ago 2>/dev/null || true
+      fi
+
+  - id: clean_stale_direnv
+    script: |
+      find ~/src -maxdepth 3 -name .direnv -type d -mtime +90 -exec rm -rf {} + 2>/dev/null || true
+
+  - id: gc
+    command: nix-collect-garbage --delete-older-than 7d
+
+  - id: optimise_store
+    command: nix store optimise

--- a/config/dagu/dags/cleanup-pre-commit.yaml
+++ b/config/dagu/dags/cleanup-pre-commit.yaml
@@ -1,0 +1,4 @@
+schedule: "0 4 * * 0"
+steps:
+  - id: gc
+    command: pre-commit gc

--- a/config/dagu/dags/cleanup-uv.yaml
+++ b/config/dagu/dags/cleanup-uv.yaml
@@ -1,0 +1,4 @@
+schedule: "0 3 * * 0"
+steps:
+  - id: cache_prune
+    command: uv cache prune

--- a/home.nix
+++ b/home.nix
@@ -47,6 +47,26 @@ let
     };
   };
 
+  dagu = pkgs.stdenv.mkDerivation rec {
+    pname = "dagu";
+    version = "2.3.8";
+    src = pkgs.fetchurl {
+      url = "https://github.com/dagu-org/dagu/releases/download/v${version}/dagu_${version}_darwin_arm64.tar.gz";
+      sha256 = "1cz16fdsg1jypa5vlrnxwsz4nq6sr5l2k1x2282mi1fhdwgpi9hl";
+    };
+    sourceRoot = ".";
+    installPhase = ''
+      mkdir -p $out/bin
+      cp dagu $out/bin/
+      chmod +x $out/bin/dagu
+    '';
+    meta = with pkgs.lib; {
+      description = "A powerful, lightweight workflow engine for scheduling and running complex pipelines";
+      homepage = "https://github.com/dagu-org/dagu";
+      platforms = [ "aarch64-darwin" ];
+    };
+  };
+
 in {
   home.username = "coneill";
   home.homeDirectory = "/Users/coneill";
@@ -90,6 +110,7 @@ in {
     nodejs_24
     p7zip
     patchutils_0_4_2
+    pre-commit
     prettyping
     pstree
     pv
@@ -111,5 +132,33 @@ in {
     watch-only
     coreutils-partial
     ts-only
+    dagu
   ];
+
+  launchd.agents.dagu = {
+    enable = true;
+    config = {
+      ProgramArguments = [
+        "${dagu}/bin/dagu"
+        "start-all"
+        "--host" "127.0.0.1"
+        "--port" "8080"
+        "--dags" "${config.home.homeDirectory}/src/dotfiles/config/dagu/dags"
+      ];
+      EnvironmentVariables = {
+        HOME = config.home.homeDirectory;
+        SHELL = "${pkgs.bash}/bin/bash";
+        PATH = "/nix/var/nix/profiles/default/bin:${config.home.homeDirectory}/.nix-profile/bin:${config.home.homeDirectory}/.orbstack/bin:/usr/bin:/bin:/usr/sbin";
+        DAGU_AUTH_MODE = "none";
+      };
+      KeepAlive = true;
+      RunAtLoad = true;
+      StandardOutPath = "${config.home.homeDirectory}/.local/share/dagu/dagu.stdout.log";
+      StandardErrorPath = "${config.home.homeDirectory}/.local/share/dagu/dagu.stderr.log";
+    };
+  };
+
+  home.activation.daguDataDir = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+    mkdir -p "${config.home.homeDirectory}/.local/share/dagu"
+  '';
 }


### PR DESCRIPTION
- Custom Nix derivation for Dagu v2.3.8
- launchd agent running on localhost:8080 with auth disabled
- Weekly cleanup workflows for Nix store, Docker, uv, pre-commit, and act caches
- Add pre-commit to global packages for scheduled GC
