### PR TITLE
Manage bash configs via home-manager, add Obsidian CLI

### DIFF
--- a/.bash_profile
+++ b/.bash_profile
@@ -27,7 +27,8 @@ move_to_front() {
 }
 
 pathmunge /usr/local/sbin
-pathmunge $HOME/bin
+pathmunge "$HOME/.local/bin"
+pathmunge "$HOME/bin"
 
 if [ -d /opt/homebrew/bin ]; then
   eval "$(/opt/homebrew/bin/brew shellenv)"
@@ -41,6 +42,11 @@ fi
 VSCODE_BINDIR="/Applications/Visual Studio Code.app/Contents/Resources/app/bin"
 if [ -d "$VSCODE_BINDIR" ]; then
   pathmunge "$VSCODE_BINDIR" after
+fi
+
+OBSIDIAN_BINDIR="/Applications/Obsidian.app/Contents/MacOS"
+if [ -d "$OBSIDIAN_BINDIR" ]; then
+  pathmunge "$OBSIDIAN_BINDIR" after
 fi
 
 if [ -d "${HOME}/.krew/bin" ]; then
@@ -81,12 +87,11 @@ if [ -f ~/.orbstack/shell/init.bash ]; then
   source ~/.orbstack/shell/init.bash
 fi
 # Nix PATH priority - ensure nix binaries come first
-# User profile must be move_to_front'd last so it ends up first in PATH
-if [ -d /nix/var/nix/profiles/default/bin ]; then
-  move_to_front /nix/var/nix/profiles/default/bin
-fi
 if [ -d ~/.nix-profile/bin ]; then
   move_to_front ~/.nix-profile/bin
+fi
+if [ -d /nix/var/nix/profiles/default/bin ]; then
+  move_to_front /nix/var/nix/profiles/default/bin
 fi
 
 # check if this is a login and/or interactive shell

--- a/.bashrc
+++ b/.bashrc
@@ -23,8 +23,7 @@ shopt -s histappend
 # Save multi-line commands as one command
 shopt -s cmdhist
 
-# Record each line as it gets issued
-PROMPT_COMMAND='history -a'
+# Note: PROMPT_COMMAND for history is handled by atuin via bash-preexec
 
 # Huge history. Doesn't appear to slow things down, so why not?
 HISTSIZE=500000
@@ -60,7 +59,15 @@ PROMPT_DIRTRIM=3
 
 alias k='kubecolor'
 
-command -v direnv &>/dev/null && eval "$(direnv hook bash)"
+# direnv integration
+if command_exists direnv; then
+  eval "$(direnv hook bash)"
+  # Claude Code runs each command in a new shell, so we need to explicitly
+  # export direnv environment on shell startup (not just on prompt)
+  if [ -n "$CLAUDECODE" ]; then
+    eval "$(DIRENV_LOG_FORMAT= direnv export bash)"
+  fi
+fi
 
 [ -f ~/.fzf.bash ] && source ~/.fzf.bash
 

--- a/home.nix
+++ b/home.nix
@@ -76,6 +76,9 @@ in {
 
   xdg.configFile."home-manager".source = config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/src/dotfiles";
 
+  home.file.".bash_profile".source = config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/src/dotfiles/.bash_profile";
+  home.file.".bashrc".source = config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/src/dotfiles/.bashrc";
+
   home.packages = with pkgs; [
     argocd
     atool


### PR DESCRIPTION
- Symlink .bash_profile and .bashrc through home-manager instead of YADM
- Add Obsidian CLI PATH entry for bash users (macOS only registers in zprofile)
- Sync repo copies with live home directory versions (direnv Claude Code
  integration, atuin history handling, ghostty shell integration)
