### PR TITLE
Add Dagu job to keep Claude session timers running

### DIFF
--- a/config/dagu/dags/start-claude-sessions.yaml
+++ b/config/dagu/dags/start-claude-sessions.yaml
@@ -1,0 +1,13 @@
+# Start Claude's 5-hour session timer so it expires and resets the
+# usage limit. Runs every 5 hours to keep a session always active.
+# Uses haiku to minimize token cost.
+schedule: "0 1,6,11,16,21 * * *"
+steps:
+  - id: claude_session
+    command: $HOME/src/dotfiles/config/dagu/scripts/start-claude-session.sh claude --model haiku -p "2+2"
+    working_dir: $HOME
+    continue_on:
+      failure: true
+  - id: claude_alt_session
+    command: $HOME/src/dotfiles/config/dagu/scripts/start-claude-session.sh claude-alt --model haiku -p "2+2"
+    working_dir: $HOME

--- a/config/dagu/dagu-wrapper.sh
+++ b/config/dagu/dagu-wrapper.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# shellcheck source=../../.bash_profile
+source "$HOME/.bash_profile"
 export DAGU_HEALTHCHECK_API_KEY="$(/usr/bin/security find-generic-password -a "$(id -un)" -s "healthchecks-api-key" -w 2>/dev/null || true)"
 export DAGU_HEALTHCHECK_PING_KEY="$(/usr/bin/security find-generic-password -a "$(id -un)" -s "healthchecks-ping-key" -w 2>/dev/null || true)"
 exec dagu start-all \

--- a/config/dagu/scripts/start-claude-session.sh
+++ b/config/dagu/scripts/start-claude-session.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -uo pipefail
+# Run a claude command, treating "Limit reached" as success.
+output=$("$@" 2>&1)
+rc=$?
+if [ "$rc" -ne 0 ] && printf '%s\n' "$output" | grep -Eq "(Limit reached|hit your limit)"; then
+  printf 'Usage limit detected: %s\n' "$output"
+  exit 0
+fi
+printf '%s\n' "$output"
+exit "$rc"

--- a/home.nix
+++ b/home.nix
@@ -147,7 +147,7 @@ in {
       EnvironmentVariables = {
         HOME = config.home.homeDirectory;
         SHELL = "${pkgs.bash}/bin/bash";
-        PATH = "/nix/var/nix/profiles/default/bin:${config.home.homeDirectory}/.nix-profile/bin:${config.home.homeDirectory}/.orbstack/bin:/usr/bin:/bin:/usr/sbin";
+        PATH = "/usr/bin:/bin:/usr/sbin";
         DAGU_AUTH_MODE = "none";
       };
       KeepAlive = true;


### PR DESCRIPTION
Starts claude and claude-alt sessions every 5 hours (centered on 6am)
using haiku to burn the session timer cheaply. This ensures the usage
limit resets before active work begins.

- Add start-claude-sessions DAG with wrapper for "Limit reached" handling
- Add ~/bin, ~/.local/bin, /opt/homebrew/bin, /usr/local/sbin to Dagu
  launchd PATH to match .bash_profile
