### PR TITLE
Add force option to flake lock update, always-run update-versions

### DIFF
--- a/.github/workflows/update-flake-lock.yaml
+++ b/.github/workflows/update-flake-lock.yaml
@@ -3,6 +3,11 @@ name: Update Nix Flake Lock
 
 on:
   workflow_dispatch:
+    inputs:
+      force:
+        description: Skip the Monday check and update immediately
+        type: boolean
+        default: false
   schedule:
     # 5am UTC daily = midnight EST / 1am EDT
   - cron: 0 5 * * *
@@ -44,8 +49,8 @@ jobs:
         GH_TOKEN: ${{ secrets.PAT }}
 
     - name: Update flake.lock
-      if: steps.check-day.outputs.is_monday == 'true' || steps.check-pr.outputs.existing_pr
-        == 'true'
+      if: (github.event_name == 'workflow_dispatch' && inputs.force) || steps.check-day.outputs.is_monday
+        == 'true' || steps.check-pr.outputs.existing_pr == 'true'
       uses: DeterminateSystems/update-flake-lock@834c491b2ece4de0bbd00d85214bb5e83b4da5c6  # v28
       id: update-flake-lock
       with:

--- a/.github/workflows/update-flake-versions.yaml
+++ b/.github/workflows/update-flake-versions.yaml
@@ -3,10 +3,7 @@ name: Update Flake Versions
 
 on:
   pull_request:
-    paths:
-    - flake.nix
-    - flake.lock
-    - home.nix
+    types: [opened, synchronize, reopened]
 
 concurrency:
   group: flake-versions-${{ github.head_ref }}
@@ -24,21 +21,35 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
       with:
         persist-credentials: false
+        fetch-depth: 0
         ref: ${{ github.head_ref }}
         token: ${{ secrets.PAT }}
 
+    - name: Check for flake changes
+      uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d  # v4
+      id: changes
+      with:
+        filters: |
+          flake:
+            - 'flake.nix'
+            - 'flake.lock'
+            - 'home.nix'
+
     - name: Install Nix
+      if: steps.changes.outputs.flake == 'true'
       uses: cachix/install-nix-action@96951a368ba55167b55f1c916f7d416bac6505fe  # v31
       with:
         github_access_token: ${{ github.token }}
 
     - name: Setup Cachix
+      if: steps.changes.outputs.flake == 'true'
       uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c  # v17
       with:
         name: claytono
         authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
     - name: Update flake-versions.yaml
+      if: steps.changes.outputs.flake == 'true'
       run: |
         nix develop --command ./scripts/gen-flake-versions --comment-file /tmp/comment.md
 


### PR DESCRIPTION
- workflow_dispatch force input skips the Monday check
- update-flake-versions uses paths-filter instead of on.paths so the job always reports a status for required checks