### PR TITLE
Isolate scheduled session start jobs

### DIFF
--- a/config/dagu/dags/start-codex-sessions.yaml
+++ b/config/dagu/dags/start-codex-sessions.yaml
@@ -1,0 +1,10 @@
+---
+# Start Codex's 5-hour session timer so it expires and resets the
+# usage limit. Runs every 5 hours to keep a session always active.
+# Uses the default Codex model from ~/.codex/config.toml.
+schedule: 0 1,6,11,16,21 * * *
+steps:
+- id: codex_session
+  command: $HOME/src/dotfiles/config/dagu/scripts/start-codex-session.sh codex exec
+    --ephemeral "2+2"
+  working_dir: $HOME

--- a/config/dagu/scripts/start-claude-session.sh
+++ b/config/dagu/scripts/start-claude-session.sh
@@ -1,8 +1,24 @@
 #!/bin/bash
 set -uo pipefail
-# Run a claude command, treating "Limit reached" as success.
-output=$("$@" 2>&1)
+
+cleanup() {
+  if [ -n "${tmpdir:-}" ] && [ -d "$tmpdir" ]; then
+    rm -rf "$tmpdir"
+  fi
+}
+
+if [ "$#" -lt 1 ]; then
+  printf 'Usage: %s <command> [args...]\n' "$0" >&2
+  exit 2
+fi
+
+tmpdir="$(mktemp -d)" || exit 1
+trap cleanup EXIT HUP INT TERM
+
+# Run Claude in an isolated temp dir, treating usage-limit output as success.
+output="$(cd "$tmpdir" && "$@" </dev/null 2>&1)"
 rc=$?
+cleanup
 if [ "$rc" -ne 0 ] && printf '%s\n' "$output" | grep -Eq "(Limit reached|hit your limit)"; then
   printf 'Usage limit detected: %s\n' "$output"
   exit 0

--- a/config/dagu/scripts/start-codex-session.sh
+++ b/config/dagu/scripts/start-codex-session.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -uo pipefail
+
+cleanup() {
+  if [ -n "${tmpdir:-}" ] && [ -d "$tmpdir" ]; then
+    rm -rf "$tmpdir"
+  fi
+}
+
+if [ "$#" -lt 2 ] || [ "$1" != "codex" ] || [ "$2" != "exec" ]; then
+  printf 'Usage: %s codex exec [args...]\n' "$0" >&2
+  exit 2
+fi
+
+tmpdir="$(mktemp -d)" || exit 1
+trap cleanup EXIT HUP INT TERM
+
+# Run Codex in an isolated temp dir, bypassing the repo check because mktemp
+# does not create a Git repo or a trusted project path.
+output="$(cd "$tmpdir" && "$1" "$2" --skip-git-repo-check -C "$tmpdir" "${@:3}" </dev/null 2>&1)"
+rc=$?
+cleanup
+if [ "$rc" -ne 0 ] && printf '%s\n' "$output" | grep -Eq "(You've hit your limit|Limit reached|hit your limit|rate_limit)"; then
+  printf 'Usage limit detected: %s\n' "$output"
+  exit 0
+fi
+printf '%s\n' "$output"
+exit "$rc"


### PR DESCRIPTION
- run the Claude and Codex session-start wrappers from mktemp workdirs with cleanup\n- add a scheduled Codex Dagu job that uses ephemeral exec with the repo check disabled for temp dirs
