### PR TITLE
Pin Codex to nixpkgs master

### DIFF
--- a/.github/workflows/flake-builds.yaml
+++ b/.github/workflows/flake-builds.yaml
@@ -50,9 +50,29 @@ jobs:
       uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c  # v17
       with:
         name: claytono
-        authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+        skipPush: true
 
     - name: Build
       if: github.event_name == 'workflow_dispatch' || steps.changes.outputs.flake
         == 'true'
-      run: nix build --print-build-logs --log-format raw --verbose ${{ matrix.flake-output }}
+      run: |
+        set -o pipefail
+        nix build --no-link --print-build-logs --log-format raw --verbose \
+          --print-out-paths ${{ matrix.flake-output }} \
+          | tee /tmp/flake-output-paths
+
+    - name: Push flake closure to Cachix
+      if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+        && (github.event_name == 'workflow_dispatch' || steps.changes.outputs.flake
+        == 'true')
+      env:
+        CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      run: |-
+        if [ -z "$CACHIX_AUTH_TOKEN" ]; then
+          echo "CACHIX_AUTH_TOKEN is not configured for claytono/dotfiles" >&2
+          exit 1
+        fi
+
+        # Push the activation package closure explicitly so substituted paths
+        # like Codex still get uploaded to Cachix on main pushes.
+        cachix push claytono < /tmp/flake-output-paths

--- a/flake-versions.yaml
+++ b/flake-versions.yaml
@@ -10,7 +10,7 @@ bash-interactive: 5.3p9
 bun: 1.3.11
 cachix: 1.11.0
 codeowners: 1.2.1
-codex: 0.118.0
+codex: 0.121.0
 curl: 8.18.0
 dagu: 2.3.8
 direnv: 2.37.1

--- a/flake.lock
+++ b/flake.lock
@@ -120,6 +120,22 @@
         "type": "github"
       }
     },
+    "nixpkgs-codex": {
+      "locked": {
+        "lastModified": 1776639730,
+        "narHash": "sha256-5O6lBzK9pUIrAo923v5lN+H+ppdz/+Izo1X54dcgWh8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "440aeee3b7e60edbf9ea7b56a4324449fa37ba27",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "master",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs-lib": {
       "locked": {
         "lastModified": 1761765539,
@@ -172,6 +188,7 @@
         "home-manager": "home-manager",
         "nix-search-cli": "nix-search-cli",
         "nixpkgs": "nixpkgs_2",
+        "nixpkgs-codex": "nixpkgs-codex",
         "strace-macos": "strace-macos"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -3,6 +3,7 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    nixpkgs-codex.url = "github:NixOS/nixpkgs/master";
 
     home-manager = {
       url = "github:nix-community/home-manager";
@@ -20,15 +21,18 @@
     };
   };
 
-  outputs = { self, nixpkgs, home-manager, nix-search-cli, strace-macos }:
+  outputs = { self, nixpkgs, nixpkgs-codex, home-manager, nix-search-cli, strace-macos }:
     let
       supportedSystems = [ "aarch64-darwin" "x86_64-linux" ];
       forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
+      codexPkgs = nixpkgs-codex.legacyPackages.aarch64-darwin;
     in {
       homeConfigurations."coneill" = home-manager.lib.homeManagerConfiguration {
         pkgs = nixpkgs.legacyPackages.aarch64-darwin;
         modules = [ ./home.nix ];
-        extraSpecialArgs = { inherit nix-search-cli strace-macos; };
+        extraSpecialArgs = {
+          inherit nix-search-cli strace-macos codexPkgs;
+        };
       };
 
       devShells = forAllSystems (system:

--- a/home.nix
+++ b/home.nix
@@ -1,4 +1,4 @@
-{ config, pkgs, lib, ... }:
+{ config, pkgs, lib, codexPkgs, ... }:
 
 let
   # Custom package to include only the watch binary from procps on macOS
@@ -133,7 +133,7 @@ in {
     dust
     cachix
     codeowners
-    codex
+    codexPkgs.codex
     curl
     direnv
     diskus


### PR DESCRIPTION
Use a dedicated nixpkgs-codex input for the Codex package.
Keep the rest of home-manager on nixpkgs-unstable and refresh the generated version snapshot.
