### PR TITLE
Use upstream Codex tags

### DIFF
--- a/.github/workflows/renovate-lint-fix.yaml
+++ b/.github/workflows/renovate-lint-fix.yaml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   fix-linting:
     name: Fix Linting Issues
-    runs-on: ubuntu-latest
+    runs-on: macos-26
     if: github.actor == 'renovate[bot]'
 
     steps:
@@ -28,9 +28,7 @@ jobs:
         ref: ${{ github.event.pull_request.head.ref }}
 
     - name: Install Nix
-      uses: cachix/install-nix-action@96951a368ba55167b55f1c916f7d416bac6505fe  # v31
-      with:
-        github_access_token: ${{ secrets.GITHUB_TOKEN }}
+      uses: DeterminateSystems/determinate-nix-action@73327eb48f028efaaf5013656ba216ca3cdeca7b  # v3.16.3
 
     - name: Setup Cachix
       uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c  # v17
@@ -43,6 +41,20 @@ jobs:
       with:
         path: ~/.cache/pre-commit
         key: ${{ runner.os }}-precommit-${{ hashFiles('.pre-commit-config.yaml') }}
+
+    - name: Refresh flake artifacts for changed inputs
+      env:
+        BASE_SHA: ${{ github.event.pull_request.base.sha }}
+      run: |
+        set -euo pipefail
+
+        if ! git diff --name-only "$BASE_SHA"...HEAD | grep -qx 'flake.nix'; then
+          echo "No flake.nix changes"
+          exit 0
+        fi
+
+        ./scripts/refresh-flake-inputs --base-ref "$BASE_SHA"
+        nix develop --command ./scripts/gen-flake-versions
 
     - name: Run pre-commit hooks on changed files
       run: |
@@ -66,12 +78,14 @@ jobs:
       env:
         BRANCH_NAME: ${{ github.event.pull_request.head.ref }}
       run: |-
+        set -euo pipefail
         git config user.name "github-actions[bot]"
         git config user.email "github-actions[bot]@users.noreply.github.com"
-        git add .
-        git commit -m "Fix linting issues
+        mapfile -t changed_files < <(git diff --name-only)
+        git add -- "${changed_files[@]}"
+        git commit -m "Apply Renovate PR fixes
 
-        Auto-fixed by pre-commit hooks"
+        Refresh flake artifacts when needed and apply pre-commit fixes."
 
         echo "Pushing fixes to branch: $BRANCH_NAME"
         git push "https://x-access-token:${{ secrets.PAT }}@github.com/${{ github.repository }}" "HEAD:$BRANCH_NAME"

--- a/.renovaterc
+++ b/.renovaterc
@@ -18,6 +18,20 @@
   "pre-commit": {
     "enabled": true
   },
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/^flake\\.nix$/"
+      ],
+      "matchStrings": [
+        "codex\\.url = \"github:openai/codex\\?ref=(?<currentValue>rust-v\\d+\\.\\d+\\.\\d+)\";"
+      ],
+      "depNameTemplate": "openai/codex",
+      "datasourceTemplate": "github-tags",
+      "versioningTemplate": "regex:^rust-v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$"
+    }
+  ],
   "packageRules": [
     {
       "matchManagers": [

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,25 @@
 {
   "nodes": {
+    "codex": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      },
+      "locked": {
+        "lastModified": 1776705009,
+        "narHash": "sha256-CpXWP64URsgt/PhQrUkrT87KG633hxRUIY0wWrTFmjk=",
+        "owner": "openai",
+        "repo": "codex",
+        "rev": "230dcadee609fa99d6162fe1107457030e5270a7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "openai",
+        "ref": "rust-v0.122.0",
+        "repo": "codex",
+        "type": "github"
+      }
+    },
     "flake-compat": {
       "flake": false,
       "locked": {
@@ -89,7 +109,7 @@
         "flake-compat": "flake-compat",
         "flake-utils": "flake-utils",
         "nix-filter": "nix-filter",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs_2"
       },
       "locked": {
         "lastModified": 1762187737,
@@ -107,31 +127,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1761752004,
-        "narHash": "sha256-z83uhYagfW6ZnH5Svvaxx6O0a305sBLGCCJZBJnMD9w=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "ddf56acbeb53825b79b82c13a657806774bfd137",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-codex": {
-      "locked": {
-        "lastModified": 1776976850,
-        "narHash": "sha256-OzW0uF3iObgWuvOzm9ub4L4t3p877gxj1EmtQuV8nlE=",
+        "lastModified": 1769461804,
+        "narHash": "sha256-msG8SU5WsBUfVVa/9RPLaymvi5bI8edTavbIq3vRlhI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0513e265c5afdce4d04c2cfccff1b51e00dbe6a7",
+        "rev": "bfc1b8a4574108ceef22f02bafcf6611380c100d",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "master",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -153,6 +158,21 @@
     },
     "nixpkgs_2": {
       "locked": {
+        "lastModified": 1761752004,
+        "narHash": "sha256-z83uhYagfW6ZnH5Svvaxx6O0a305sBLGCCJZBJnMD9w=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "ddf56acbeb53825b79b82c13a657806774bfd137",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_3": {
+      "locked": {
         "lastModified": 1776329215,
         "narHash": "sha256-a8BYi3mzoJ/AcJP8UldOx8emoPRLeWqALZWu4ZvjPXw=",
         "owner": "NixOS",
@@ -167,7 +187,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_3": {
+    "nixpkgs_4": {
       "locked": {
         "lastModified": 1763283776,
         "narHash": "sha256-Y7TDFPK4GlqrKrivOcsHG8xSGqQx3A6c+i7novT85Uk=",
@@ -185,17 +205,38 @@
     },
     "root": {
       "inputs": {
+        "codex": "codex",
         "home-manager": "home-manager",
         "nix-search-cli": "nix-search-cli",
-        "nixpkgs": "nixpkgs_2",
-        "nixpkgs-codex": "nixpkgs-codex",
+        "nixpkgs": "nixpkgs_3",
         "strace-macos": "strace-macos"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "codex",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1769828398,
+        "narHash": "sha256-zmnvRUm15QrlKH0V1BZoiT3U+Q+tr+P5Osi8qgtL9fY=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "a1d32c90c8a4ea43e9586b7e5894c179d5747425",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
       }
     },
     "strace-macos": {
       "inputs": {
         "flake-parts": "flake-parts",
-        "nixpkgs": "nixpkgs_3",
+        "nixpkgs": "nixpkgs_4",
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
-    nixpkgs-codex.url = "github:NixOS/nixpkgs/master";
+    codex.url = "github:openai/codex?ref=rust-v0.122.0";
 
     home-manager = {
       url = "github:nix-community/home-manager";
@@ -21,17 +21,139 @@
     };
   };
 
-  outputs = { self, nixpkgs, nixpkgs-codex, home-manager, nix-search-cli, strace-macos }:
+  outputs = { self, nixpkgs, codex, home-manager, nix-search-cli, strace-macos }:
     let
       supportedSystems = [ "aarch64-darwin" "x86_64-linux" ];
       forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
-      codexPkgs = nixpkgs-codex.legacyPackages.aarch64-darwin;
+      darwinPkgs = nixpkgs.legacyPackages.aarch64-darwin;
+      codexSource = codex.outPath;
+      codexVersion =
+        (builtins.fromTOML (builtins.readFile (codexSource + "/codex-rs/Cargo.toml")))
+        .workspace.package.version;
+      codexCargoLock =
+        builtins.fromTOML (builtins.readFile (codexSource + "/codex-rs/Cargo.lock"));
+      codexV8Version =
+        (nixpkgs.lib.findFirst
+          (pkg: pkg.name == "v8")
+          (throw "Unable to find v8 crate in Codex Cargo.lock")
+          codexCargoLock.package
+        ).version;
+      librustyV8 = darwinPkgs.fetchurl {
+        url = "https://github.com/denoland/rusty_v8/releases/download/v${codexV8Version}/librusty_v8_release_aarch64-apple-darwin.a.gz";
+        hash = "sha256-v+LJvjKlbChUbw+WWCXuaPv2BkBfMQzE4XtEilaM+Yo=";
+      };
+      codexPackage = {
+        lib,
+        rustPlatform,
+        stdenv,
+        installShellFiles,
+        bubblewrap,
+        clang,
+        cmake,
+        gitMinimal,
+        libcap,
+        libclang,
+        livekit-libwebrtc,
+        makeBinaryWrapper,
+        pkg-config,
+        openssl,
+        ripgrep,
+        versionCheckHook,
+        installShellCompletions ? stdenv.buildPlatform.canExecute stdenv.hostPlatform,
+        ...
+      }:
+        rustPlatform.buildRustPackage (finalAttrs: {
+          pname = "codex";
+          version = codexVersion;
+
+          src = codexSource;
+          sourceRoot = "source/codex-rs";
+
+          cargoHash = "sha256-2qtMLWSdYWJ+blNfCHXtgmzizuM1HgpTGa5RQ3U/AEM=";
+
+          cargoBuildFlags = [
+            "--package"
+            "codex-cli"
+          ];
+          cargoCheckFlags = [
+            "--package"
+            "codex-cli"
+          ];
+
+          postPatch = ''
+            substituteInPlace $cargoDepsCopy/*/webrtc-sys-*/build.rs \
+              --replace-fail "cargo:rustc-link-lib=static=webrtc" "cargo:rustc-link-lib=dylib=webrtc"
+
+            substituteInPlace Cargo.toml \
+              --replace-fail 'lto = "fat"' "" \
+              --replace-fail 'codegen-units = 1' ""
+          '';
+
+          nativeBuildInputs = [
+            clang
+            cmake
+            gitMinimal
+            installShellFiles
+            makeBinaryWrapper
+            pkg-config
+          ];
+
+          buildInputs = [
+            libclang
+            openssl
+          ]
+          ++ lib.optionals stdenv.hostPlatform.isLinux [
+            libcap
+          ];
+
+          env = {
+            LIBCLANG_PATH = "${lib.getLib libclang}/lib";
+            LK_CUSTOM_WEBRTC = lib.getDev livekit-libwebrtc;
+            NIX_CFLAGS_COMPILE = toString (
+              lib.optionals stdenv.cc.isGNU [
+                "-Wno-error=stringop-overflow"
+              ]
+              ++ lib.optionals stdenv.cc.isClang [
+                "-Wno-error=character-conversion"
+              ]
+            );
+            RUSTY_V8_ARCHIVE = librustyV8;
+          };
+
+          doCheck = false;
+
+          postInstall = lib.optionalString installShellCompletions ''
+            installShellCompletion --cmd codex \
+              --bash <($out/bin/codex completion bash) \
+              --fish <($out/bin/codex completion fish) \
+              --zsh <($out/bin/codex completion zsh)
+          '';
+
+          postFixup = ''
+            wrapProgram $out/bin/codex --prefix PATH : ${
+              lib.makeBinPath ([ ripgrep ] ++ lib.optionals stdenv.hostPlatform.isLinux [ bubblewrap ])
+            }
+          '';
+
+          doInstallCheck = true;
+          nativeInstallCheckInputs = [ versionCheckHook ];
+
+          meta = {
+            description = "Lightweight coding agent that runs in your terminal";
+            homepage = "https://github.com/openai/codex";
+            changelog = "https://raw.githubusercontent.com/openai/codex/refs/tags/rust-v${finalAttrs.version}/CHANGELOG.md";
+            license = lib.licenses.asl20;
+            mainProgram = "codex";
+            platforms = lib.platforms.unix;
+          };
+        });
+      codexPkg = darwinPkgs.callPackage codexPackage { };
     in {
       homeConfigurations."coneill" = home-manager.lib.homeManagerConfiguration {
         pkgs = nixpkgs.legacyPackages.aarch64-darwin;
         modules = [ ./home.nix ];
         extraSpecialArgs = {
-          inherit nix-search-cli strace-macos codexPkgs;
+          inherit nix-search-cli strace-macos codexPkg;
         };
       };
 

--- a/home.nix
+++ b/home.nix
@@ -1,4 +1,4 @@
-{ config, pkgs, lib, codexPkgs, ... }:
+{ config, pkgs, lib, codexPkg, ... }:
 
 let
   # Custom package to include only the watch binary from procps on macOS
@@ -133,7 +133,7 @@ in {
     dust
     cachix
     codeowners
-    codexPkgs.codex
+    codexPkg
     curl
     direnv
     diskus

--- a/scripts/refresh-flake-inputs
+++ b/scripts/refresh-flake-inputs
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""Refresh flake inputs, then rebuild and auto-fix hash mismatches."""
+
+import argparse
+import io
+import json
+import shlex
+import shutil
+import subprocess
+import tarfile
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_BUILD_TARGET = ".#homeConfigurations.coneill.activationPackage"
+DEFAULT_FIX_HASHES_COMMAND = "determinate-nixd fix hashes --auto-apply"
+
+
+def run(
+    *args: str,
+    cwd: Path = REPO_ROOT,
+    capture_output: bool = False,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        args,
+        cwd=cwd,
+        check=True,
+        text=True,
+        capture_output=capture_output,
+    )
+
+
+def metadata(path: Path) -> dict:
+    result = run("nix", "flake", "metadata", "--json", str(path), capture_output=True)
+    return json.loads(result.stdout)
+
+
+def top_level_inputs(meta: dict) -> dict[str, dict]:
+    nodes = meta["locks"]["nodes"]
+    root_inputs = nodes["root"]["inputs"]
+    return {
+        name: {
+            "node": root_inputs[name],
+            "original": nodes[root_inputs[name]].get("original"),
+        }
+        for name in sorted(root_inputs)
+    }
+
+
+def snapshot(ref: str) -> Path:
+    tempdir = Path(tempfile.mkdtemp(prefix="flake-inputs-"))
+    archive = subprocess.run(
+        ["git", "archive", "--format=tar", ref],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+    )
+    with tarfile.open(fileobj=io.BytesIO(archive.stdout)) as tf:
+        tf.extractall(tempdir, filter="data")
+    return tempdir
+
+
+def changed_inputs(base_ref: str) -> tuple[dict[str, dict], list[str]]:
+    current = top_level_inputs(metadata(REPO_ROOT))
+    base_dir = snapshot(base_ref)
+    try:
+        base = top_level_inputs(metadata(base_dir))
+    finally:
+        shutil.rmtree(base_dir)
+
+    changed = []
+    for name, current_info in current.items():
+        base_info = base.get(name)
+        if base_info is None or base_info["original"] != current_info["original"]:
+            changed.append(name)
+    return current, changed
+
+
+def print_inputs(current: dict[str, dict], changed: set[str]) -> None:
+    for name in current:
+        suffix = " changed" if name in changed else ""
+        print(f"{name}{suffix}")
+
+
+def resolve_inputs(
+    *,
+    available: dict[str, dict],
+    changed: list[str],
+    selected: list[str],
+    update_all: bool,
+    base_ref: str | None,
+) -> list[str]:
+    if update_all:
+        return list(available.keys())
+
+    if selected:
+        unknown = [name for name in selected if name not in available]
+        if unknown:
+            raise SystemExit(f"Unknown flake inputs: {', '.join(unknown)}")
+        return selected
+
+    if base_ref is not None:
+        return changed
+
+    raise SystemExit("Specify input names, --all, or --base-ref")
+
+
+def hash_fix_command(command: str) -> list[str]:
+    return shlex.split(command)
+
+
+def ensure_hash_fixer(command: str) -> None:
+    binary = hash_fix_command(command)[0]
+    if shutil.which(binary):
+        return
+    raise SystemExit(
+        f"Hash fixer '{binary}' is not on PATH. "
+        f"Set --fix-hashes-command or install it before running updates."
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "inputs", nargs="*", help="Specific top-level flake inputs to update"
+    )
+    parser.add_argument(
+        "--all",
+        action="store_true",
+        help="Update all top-level flake inputs",
+    )
+    parser.add_argument(
+        "--base-ref",
+        help="Detect changed top-level inputs by comparing against this git ref",
+    )
+    parser.add_argument(
+        "--build-target",
+        default=DEFAULT_BUILD_TARGET,
+        help=f"Flake target to build after updating inputs (default: {DEFAULT_BUILD_TARGET})",
+    )
+    parser.add_argument(
+        "--fix-hashes-command",
+        default=DEFAULT_FIX_HASHES_COMMAND,
+        help=f"Command to run when the build fails (default: {DEFAULT_FIX_HASHES_COMMAND!r})",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show the planned updates and commands without mutating anything",
+    )
+    parser.add_argument(
+        "--list",
+        action="store_true",
+        help="List top-level inputs, marking detected changes when --base-ref is set",
+    )
+    args = parser.parse_args()
+
+    if args.all and args.inputs:
+        raise SystemExit("Pass input names or --all, not both")
+
+    current = top_level_inputs(metadata(REPO_ROOT))
+    changed = []
+    if args.base_ref is not None:
+        current, changed = changed_inputs(args.base_ref)
+
+    if args.list:
+        print_inputs(current, set(changed))
+        return 0
+
+    selected = resolve_inputs(
+        available=current,
+        changed=changed,
+        selected=args.inputs,
+        update_all=args.all,
+        base_ref=args.base_ref,
+    )
+
+    if not selected:
+        print("No flake inputs selected")
+        return 0
+
+    print("Selected inputs:")
+    for name in selected:
+        print(f"- {name}")
+
+    if args.dry_run:
+        for name in selected:
+            print(f"would run: nix flake update {name}")
+        print(f"would run: nix build --no-link --print-build-logs {args.build_target}")
+        print(f"would run on build failure: {args.fix_hashes_command}")
+        print(
+            f"would rerun: nix build --no-link --print-build-logs {args.build_target}"
+        )
+        return 0
+
+    ensure_hash_fixer(args.fix_hashes_command)
+
+    for name in selected:
+        run("nix", "flake", "update", name)
+
+    build_status = subprocess.run(
+        ["nix", "build", "--no-link", "--print-build-logs", args.build_target],
+        cwd=REPO_ROOT,
+        text=True,
+    ).returncode
+    if build_status == 0:
+        return 0
+
+    run(*hash_fix_command(args.fix_hashes_command))
+    run("nix", "build", "--no-link", "--print-build-logs", args.build_target)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Source Codex from upstream release tags instead of nixpkgs.

Add Renovate support for the tagged flake input and refresh flake artifacts when Renovate updates the Codex tag.

Pin the repo back to rust-v0.122.0 so the next bump exercises the Renovate flow.
