### PR TITLE
Add restore key for fixer cache

### DIFF
--- a/.github/workflows/renovate-lint-fix.yaml
+++ b/.github/workflows/renovate-lint-fix.yaml
@@ -62,6 +62,8 @@ jobs:
       with:
         path: ~/.cache/pre-commit
         key: ${{ runner.os }}-precommit-${{ hashFiles('.pre-commit-config.yaml') }}
+        restore-keys: |
+          ${{ runner.os }}-precommit-
 
     - name: No relevant changes
       if: steps.changes.outputs.lintable != 'true'


### PR DESCRIPTION
- let the macOS Renovate fixer reuse older pre-commit caches
- keep the exact key tied to .pre-commit-config.yaml
