### PR TITLE
Restore tmux status styling

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -24,8 +24,32 @@ if-shell '[[ $(uname -s) = Darwin ]]' {
   }
 }
 
+# Status bar
+set -g status-position top
+set -g status-style "bg=#1a1b26,fg=#c0caf5"
+set -g status-left "#[bg=#7aa2f7,fg=#1a1b26,bold]  #S #[bg=#1a1b26,fg=#7aa2f7] "
+set -g status-left-length 30
+set -g status-right "#[fg=#565f89]#[bg=#565f89,fg=#c0caf5] %l:%M%p #[fg=#7aa2f7]#[bg=#7aa2f7,fg=#1a1b26,bold] %d-%b "
+set -g status-right-length 40
+
+# Window tabs
+set -g window-status-format "#[fg=#737aa2] #I:#W "
+set -g window-status-current-format "#[fg=#1a1b26,bg=#9ece6a]#[fg=#1a1b26,bg=#9ece6a,bold] #I:#W #[fg=#9ece6a,bg=#1a1b26]"
+set -g window-status-separator ""
+
+# Pane borders
+set -g pane-border-style "fg=#3b4261"
+set -g pane-active-border-style "fg=#7aa2f7"
+
+# Message style
+set -g message-style "bg=#7aa2f7,fg=#1a1b26"
+
+set -g mouse on
+
+set -g base-index 1
+bind 0 select-window -t :10
+
 new-session -A -s main
-new-window -t main:1
 new-window -t main:2
 new-window -t main:3
 new-window -t main:4
@@ -34,3 +58,4 @@ new-window -t main:6
 new-window -t main:7
 new-window -t main:8
 new-window -t main:9
+new-window -t main:10

--- a/home.nix
+++ b/home.nix
@@ -121,6 +121,7 @@ in {
 
   home.file.".bash_profile".source = config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/src/dotfiles/.bash_profile";
   home.file.".bashrc".source = config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/src/dotfiles/.bashrc";
+  home.file.".tmux.conf".source = config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/src/dotfiles/.tmux.conf";
   home.file."bin/ssh-known-hosts-update".source = config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/src/dotfiles/scripts/ssh-known-hosts-update";
 
   home.packages = with pkgs; [


### PR DESCRIPTION
Restore the tmux status bar styling recovered from the previous local configuration.

- Put the status bar at the top with the tuned colors
- Manage .tmux.conf through Home Manager again
