### PR TITLE
Add PR 39 Tailscale SSH diagnostics

### DIFF
--- a/.github/workflows/flake-builds.yaml
+++ b/.github/workflows/flake-builds.yaml
@@ -52,6 +52,18 @@ jobs:
         name: claytono
         skipPush: true
 
+    - name: Start Tailscale SSH
+      # Temporary diagnostics for PR 39. Remove after the long-running Codex
+      # build is understood.
+      if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request'
+        && steps.changes.outputs.flake == 'true')
+      uses: claytono/github-actions/tailscale-ssh@ef5adfc30461da4e7f1aad700b1ddfd39b2dbd61
+      with:
+        oauth-client-id: ${{ secrets.TAILSCALE_SSH_OAUTH_CLIENT_ID }}
+        oauth-secret: ${{ secrets.TAILSCALE_SSH_OAUTH_CLIENT_SECRET }}
+        hostname: dotfiles-flake-${{ github.run_id }}-${{ github.run_attempt }}
+        mode: background
+
     - name: Build
       if: github.event_name == 'workflow_dispatch' || steps.changes.outputs.flake
         == 'true'


### PR DESCRIPTION
Start the reusable Tailscale SSH action in background mode before the flake build when the build job is active.

This is temporary diagnostic plumbing for the long-running Codex build on PR 39 and should be removed after the build behavior is understood.