### PR TITLE
Build and cache flake outputs across platforms

### DIFF
--- a/.github/workflows/flake-builds.yaml
+++ b/.github/workflows/flake-builds.yaml
@@ -13,11 +13,27 @@ jobs:
     name: Build flake outputs (${{ matrix.label }})
     runs-on: ${{ matrix.runs-on }}
     strategy:
+      fail-fast: false
       matrix:
         include:
         - label: home-manager (macos arm64)
           runs-on: macos-26
-          flake-output: .#homeConfigurations.coneill.activationPackage
+          flake-output: .#homeConfigurations.coneill-aarch64-darwin.activationPackage
+          codex-output: .#packages.aarch64-darwin.codex
+          nix-cores: ''
+          extra-swap-size-gb: ''
+        - label: home-manager (linux arm64)
+          runs-on: ubuntu-24.04-arm
+          flake-output: .#homeConfigurations.coneill-aarch64-linux.activationPackage
+          codex-output: .#packages.aarch64-linux.codex
+          nix-cores: '1'
+          extra-swap-size-gb: '8'
+        - label: home-manager (linux amd64)
+          runs-on: ubuntu-24.04
+          flake-output: .#homeConfigurations.coneill-x86_64-linux.activationPackage
+          codex-output: .#packages.x86_64-linux.codex
+          nix-cores: ''
+          extra-swap-size-gb: ''
 
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
@@ -61,6 +77,20 @@ jobs:
         hostname: dotfiles-flake-${{ github.run_id }}-${{ github.run_attempt }}
         mode: background
 
+    - name: Add extra swap
+      if: steps.changes.outputs.flake != 'false' && matrix.extra-swap-size-gb != ''
+      run: |
+        set -euo pipefail
+
+        swap_size_gb='${{ matrix.extra-swap-size-gb }}'
+        swapfile=/mnt/github-actions-extra.swap
+
+        sudo fallocate -l "${swap_size_gb}G" "$swapfile"
+        sudo chmod 600 "$swapfile"
+        sudo mkswap "$swapfile"
+        sudo swapon "$swapfile"
+        swapon --show
+
     - name: Build
       if: steps.changes.outputs.flake != 'false'
       env:
@@ -69,13 +99,19 @@ jobs:
         set -o pipefail
 
         flake_output='${{ matrix.flake-output }}'
+        codex_output='${{ matrix.codex-output }}'
+        nix_cores='${{ matrix.nix-cores }}'
         build_command=(
           nix build
           --no-link
           --keep-going
           --print-out-paths
-          "$flake_output"
+          --max-jobs 1
         )
+        if [ -n "$nix_cores" ]; then
+          build_command+=(--cores "$nix_cores")
+        fi
+        build_command+=("$flake_output" "$codex_output")
 
         build_output=/tmp/flake-build-output
         output_paths=/tmp/flake-output-paths
@@ -117,6 +153,6 @@ jobs:
           exit 0
         fi
 
-        # Push the activation package closure explicitly so substituted paths
-        # like Codex still get uploaded to Cachix on main pushes.
+        # Push final flake output closures explicitly so substituted paths
+        # still get uploaded to Cachix on main pushes.
         cachix push claytono < /tmp/flake-output-paths

--- a/flake.nix
+++ b/flake.nix
@@ -23,9 +23,7 @@
 
   outputs = { self, nixpkgs, codex, home-manager, nix-search-cli, strace-macos }:
     let
-      supportedSystems = [ "aarch64-darwin" "x86_64-linux" ];
-      forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
-      darwinPkgs = nixpkgs.legacyPackages.aarch64-darwin;
+      pkgsFor = system: nixpkgs.legacyPackages.${system};
       codexSource = codex.outPath;
       codexVersion =
         (builtins.fromTOML (builtins.readFile (codexSource + "/codex-rs/Cargo.toml")))
@@ -38,10 +36,31 @@
           (throw "Unable to find v8 crate in Codex Cargo.lock")
           codexCargoLock.package
         ).version;
-      librustyV8 = darwinPkgs.fetchurl {
-        url = "https://github.com/denoland/rusty_v8/releases/download/v${codexV8Version}/librusty_v8_release_aarch64-apple-darwin.a.gz";
-        hash = "sha256-v+LJvjKlbChUbw+WWCXuaPv2BkBfMQzE4XtEilaM+Yo=";
+      rustyV8Archives = {
+        aarch64-darwin = {
+          platform = "aarch64-apple-darwin";
+          hash = "sha256-v+LJvjKlbChUbw+WWCXuaPv2BkBfMQzE4XtEilaM+Yo=";
+        };
+        aarch64-linux = {
+          platform = "aarch64-unknown-linux-gnu";
+          hash = "sha256-2/FlsHyBvbBUvARrQ9I+afz3vMGkwbW0d2mDpxBi7Ng=";
+        };
+        x86_64-linux = {
+          platform = "x86_64-unknown-linux-gnu";
+          hash = "sha256-5ktNmeSuKTouhGJEqJuAF4uhA4LBP7WRwfppaPUpEVM=";
+        };
       };
+      supportedSystems = builtins.attrNames rustyV8Archives;
+      forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
+      librustyV8For = system:
+        let
+          pkgs = pkgsFor system;
+          archive = rustyV8Archives.${system};
+        in
+          pkgs.fetchurl {
+            url = "https://github.com/denoland/rusty_v8/releases/download/v${codexV8Version}/librusty_v8_release_${archive.platform}.a.gz";
+            hash = archive.hash;
+          };
       codexPackage = {
         lib,
         rustPlatform,
@@ -59,6 +78,7 @@
         openssl,
         ripgrep,
         versionCheckHook,
+        librustyV8,
         installShellCompletions ? stdenv.buildPlatform.canExecute stdenv.hostPlatform,
         ...
       }:
@@ -147,18 +167,39 @@
             platforms = lib.platforms.unix;
           };
         });
-      codexPkg = darwinPkgs.callPackage codexPackage { };
-    in {
-      homeConfigurations."coneill" = home-manager.lib.homeManagerConfiguration {
-        pkgs = nixpkgs.legacyPackages.aarch64-darwin;
-        modules = [ ./home.nix ];
-        extraSpecialArgs = {
-          inherit nix-search-cli strace-macos codexPkg;
+      codexPkgFor = system: (pkgsFor system).callPackage codexPackage {
+        librustyV8 = librustyV8For system;
+      };
+      homeConfigurationFor = system:
+        home-manager.lib.homeManagerConfiguration {
+          pkgs = pkgsFor system;
+          modules = [ ./home.nix ];
+          extraSpecialArgs = {
+            inherit nix-search-cli strace-macos;
+            codexPkg = codexPkgFor system;
+          };
         };
+      systemHomeConfigurations =
+        builtins.listToAttrs (map (system: {
+          name = "coneill-${system}";
+          value = homeConfigurationFor system;
+        }) supportedSystems);
+    in {
+      lib = {
+        inherit codexV8Version rustyV8Archives supportedSystems;
+      };
+
+      packages = forAllSystems (system: {
+        codex = codexPkgFor system;
+        default = codexPkgFor system;
+      });
+
+      homeConfigurations = systemHomeConfigurations // {
+        coneill = systemHomeConfigurations.coneill-aarch64-darwin;
       };
 
       devShells = forAllSystems (system:
-        let pkgs = nixpkgs.legacyPackages.${system};
+        let pkgs = pkgsFor system;
         in {
           default = pkgs.mkShell {
             packages = [
@@ -167,6 +208,7 @@
               (pkgs.python313.withPackages (ps: [ ps.pyyaml ]))
             ];
           };
-        });
+        }
+      );
     };
 }

--- a/home.nix
+++ b/home.nix
@@ -1,6 +1,9 @@
 { config, pkgs, lib, codexPkg, ... }:
 
 let
+  username = "coneill";
+  homeDirectory = if pkgs.stdenv.isDarwin then "/Users/${username}" else "/home/${username}";
+
   # Custom package to include only the watch binary from procps on macOS
   watch-only = pkgs.stdenv.mkDerivation {
     name = "watch-only";
@@ -47,29 +50,30 @@ let
     };
   };
 
-  dagu = pkgs.stdenv.mkDerivation rec {
-    pname = "dagu";
-    version = "2.3.8";
-    src = pkgs.fetchurl {
-      url = "https://github.com/dagu-org/dagu/releases/download/v${version}/dagu_${version}_darwin_arm64.tar.gz";
-      sha256 = "1cz16fdsg1jypa5vlrnxwsz4nq6sr5l2k1x2282mi1fhdwgpi9hl";
+  dagu =
+    pkgs.stdenv.mkDerivation rec {
+      pname = "dagu";
+      version = "2.3.8";
+      src = pkgs.fetchurl {
+        url = "https://github.com/dagu-org/dagu/releases/download/v${version}/dagu_${version}_darwin_arm64.tar.gz";
+        hash = "sha256-FKZ4H2/QhVgFEqKHKWjJ2mBLvubdZrqLul6Gp5sz4bM=";
+      };
+      sourceRoot = ".";
+      installPhase = ''
+        mkdir -p $out/bin
+        cp dagu $out/bin/
+        chmod +x $out/bin/dagu
+      '';
+      meta = with pkgs.lib; {
+        description = "A powerful, lightweight workflow engine for scheduling and running complex pipelines";
+        homepage = "https://github.com/dagu-org/dagu";
+        platforms = [ "aarch64-darwin" ];
+      };
     };
-    sourceRoot = ".";
-    installPhase = ''
-      mkdir -p $out/bin
-      cp dagu $out/bin/
-      chmod +x $out/bin/dagu
-    '';
-    meta = with pkgs.lib; {
-      description = "A powerful, lightweight workflow engine for scheduling and running complex pipelines";
-      homepage = "https://github.com/dagu-org/dagu";
-      platforms = [ "aarch64-darwin" ];
-    };
-  };
 
 in {
-  home.username = "coneill";
-  home.homeDirectory = "/Users/coneill";
+  home.username = username;
+  home.homeDirectory = homeDirectory;
   home.stateVersion = "24.05";
 
   programs.home-manager.enable = true;
@@ -184,7 +188,7 @@ in {
     dagu
   ];
 
-  launchd.agents.dagu = {
+  launchd.agents.dagu = lib.mkIf pkgs.stdenv.isDarwin {
     enable = true;
     config = {
       ProgramArguments = [
@@ -203,7 +207,7 @@ in {
     };
   };
 
-  home.activation.daguDataDir = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+  home.activation.daguDataDir = lib.mkIf pkgs.stdenv.isDarwin (lib.hm.dag.entryAfter [ "writeBoundary" ] ''
     mkdir -p "${config.home.homeDirectory}/.local/share/dagu"
-  '';
+  '');
 }


### PR DESCRIPTION
Add explicit Home Manager and Codex package outputs for macOS arm64, Linux arm64, and Linux amd64.

Make the shared Home Manager module portable across Darwin and Linux by deriving the home directory from the target platform and guarding Darwin-only Dagu setup.

Expand the flake build workflow to:
- build each platform's Home Manager activation package and Codex package on matching GitHub-hosted runners
- upload completed build products through Cachix as they finish
- keep Linux arm64 serialized and add matrix-controlled extra swap for Deno's final LTO link

Keep the default `coneill` Home Manager alias pointed at the macOS arm64 configuration.
