### PR TITLE
Configure Beads embedded Dolt

### DIFF
--- a/.beads/config.yaml
+++ b/.beads/config.yaml
@@ -1,3 +1,8 @@
 ---
 issue-prefix: dotfiles
-sync-branch: beads-sync
+sync-branch: ''
+
+export:
+  auto: false
+
+sync.remote: git+ssh://git@github.com/claytono/dotfiles.git

--- a/.beads/metadata.json
+++ b/.beads/metadata.json
@@ -1,4 +1,6 @@
 {
-  "database": "beads.db",
-  "jsonl_export": "issues.jsonl"
+  "database": "dolt",
+  "backend": "dolt",
+  "dolt_mode": "embedded",
+  "dolt_database": "dotfiles"
 }

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,6 @@ config/dagu/dags/memory/
 config/dagu/dags/skills/
 config/dagu/dags/souls/
 
-# Beads (JSONL committed only to beads-sync branch)
+# Beads local JSONL exports
 .beads/issues.jsonl
 .beads/interactions.jsonl

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,14 +52,3 @@ repos:
   rev: v1.7.12
   hooks:
   - id: actionlint
-
-- repo: local
-  hooks:
-  - id: beads-flush
-    name: beads pre-commit flush
-    entry: bash -c '[ "$GITHUB_ACTIONS" = "true" ] && exit 0; [ "$(git rev-parse --abbrev-ref
-      HEAD)" != "beads-sync" ] && exit 0; bd hooks run pre-commit'
-    language: system
-    pass_filenames: false
-    always_run: true
-    stages: [pre-commit]


### PR DESCRIPTION
Switch Beads metadata to the embedded Dolt backend and point sync at the dotfiles repository.

Disable automatic JSONL export and remove the obsolete beads-sync pre-commit hook now that JSONL files are local exports.
