### PR TITLE
Refresh declared fixed-output hashes

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -52,6 +52,15 @@
       };
       supportedSystems = builtins.attrNames rustyV8Archives;
       forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
+      refreshableFixedOutputs = map (system:
+        let archive = rustyV8Archives.${system};
+        in {
+          input = "codex";
+          file = "flake.nix";
+          attrPath = [ "rustyV8Archives" system "hash" ];
+          url = "https://github.com/denoland/rusty_v8/releases/download/v${codexV8Version}/librusty_v8_release_${archive.platform}.a.gz";
+          hashType = "sha256";
+        }) supportedSystems;
       librustyV8For = system:
         let
           pkgs = pkgsFor system;
@@ -186,7 +195,7 @@
         }) supportedSystems);
     in {
       lib = {
-        inherit codexV8Version rustyV8Archives supportedSystems;
+        inherit codexV8Version refreshableFixedOutputs rustyV8Archives supportedSystems;
       };
 
       packages = forAllSystems (system: {

--- a/scripts/refresh-flake-inputs
+++ b/scripts/refresh-flake-inputs
@@ -5,6 +5,7 @@ import argparse
 import difflib
 import io
 import json
+import re
 import shlex
 import shutil
 import subprocess
@@ -18,6 +19,7 @@ DEFAULT_FIX_HASHES_COMMAND = "determinate-nixd fix hashes --auto-apply"
 FALLBACK_FIX_HASHES_COMMAND = (
     "nix run github:DeterminateSystems/determinate -- fix hashes --auto-apply"
 )
+REFRESHABLE_FIXED_OUTPUTS_ATTR = ".#lib.refreshableFixedOutputs"
 IGNORED_TREE_NAMES = frozenset({".git", ".beads", "__pycache__", "result"})
 COPY_IGNORE = shutil.ignore_patterns(*sorted(IGNORED_TREE_NAMES))
 
@@ -173,6 +175,175 @@ def working_tree_diff(*, cwd: Path) -> str:
     ).stdout
 
 
+def nix_eval_json(attr: str, *, cwd: Path) -> object:
+    result = run("nix", "eval", "--json", attr, cwd=cwd, capture_output=True)
+    return json.loads(result.stdout)
+
+
+def prefetch_file_hash(url: str, *, hash_type: str, cwd: Path) -> str:
+    result = run(
+        "nix",
+        "store",
+        "prefetch-file",
+        "--json",
+        "--hash-type",
+        hash_type,
+        url,
+        cwd=cwd,
+        capture_output=True,
+    )
+    return json.loads(result.stdout)["hash"]
+
+
+def nix_attr_name_pattern(attr_name: str) -> str:
+    escaped = re.escape(attr_name)
+    return rf'(?:{escaped}|"{escaped}")'
+
+
+def find_matching_brace(text: str, open_index: int) -> int:
+    depth = 0
+    in_string = False
+    escaped = False
+    in_line_comment = False
+
+    for index in range(open_index, len(text)):
+        char = text[index]
+
+        if in_line_comment:
+            if char == "\n":
+                in_line_comment = False
+            continue
+
+        if in_string:
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == '"':
+                in_string = False
+            continue
+
+        if char == "#":
+            in_line_comment = True
+            continue
+        if char == '"':
+            in_string = True
+            continue
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                return index
+
+    raise SystemExit("Unable to find matching closing brace")
+
+
+def find_attrset_body(
+    text: str, *, attr_path: list[str], display_path: Path
+) -> tuple[int, int]:
+    start = 0
+    end = len(text)
+
+    for attr_name in attr_path:
+        attr_pattern = nix_attr_name_pattern(attr_name)
+        pattern = re.compile(
+            rf"^[ \t]*{attr_pattern}[ \t]*=[ \t]*\{{",
+            re.MULTILINE,
+        )
+        match = pattern.search(text, start, end)
+        if match is None:
+            raise SystemExit(
+                f"Unable to find attrset for {'.'.join(attr_path)} in {display_path}"
+            )
+        open_index = text.find("{", match.start(), match.end())
+        close_index = find_matching_brace(text, open_index)
+        start = open_index + 1
+        end = close_index
+
+    return start, end
+
+
+def update_string_attr(
+    *,
+    text: str,
+    attr_path: list[str],
+    new_value: str,
+    display_path: Path,
+) -> str:
+    if not attr_path:
+        raise SystemExit("Fixed-output record attrPath must not be empty")
+
+    parent_start, parent_end = find_attrset_body(
+        text,
+        attr_path=attr_path[:-1],
+        display_path=display_path,
+    )
+    final_attr = attr_path[-1]
+    final_pattern = nix_attr_name_pattern(final_attr)
+    pattern = re.compile(
+        rf'(?P<prefix>^[ \t]*{final_pattern}[ \t]*=[ \t]*")[^"]+'
+        rf'(?P<suffix>"[ \t]*;)',
+        re.MULTILINE,
+    )
+
+    matches = list(pattern.finditer(text, parent_start, parent_end))
+    if len(matches) != 1:
+        raise SystemExit(
+            f"Unable to update {'.'.join(attr_path)} in {display_path}; "
+            f"expected one string assignment, found {len(matches)}"
+        )
+
+    match = matches[0]
+    replacement = f"{match.group('prefix')}{new_value}{match.group('suffix')}"
+    return text[: match.start()] + replacement + text[match.end() :]
+
+
+def update_declared_fixed_output(record: dict, *, cwd: Path) -> None:
+    file_path = cwd / record["file"]
+    attr_path = record["attrPath"]
+    if not isinstance(attr_path, list) or not all(
+        isinstance(attr, str) for attr in attr_path
+    ):
+        raise SystemExit("Fixed-output record attrPath must be a list of strings")
+
+    new_hash = prefetch_file_hash(
+        record["url"],
+        hash_type=record.get("hashType", "sha256"),
+        cwd=cwd,
+    )
+    original = file_path.read_text()
+    updated = update_string_attr(
+        text=original,
+        attr_path=attr_path,
+        new_value=new_hash,
+        display_path=file_path.relative_to(cwd),
+    )
+    if updated != original:
+        file_path.write_text(updated)
+
+    print(f"- {record['file']}:{'.'.join(attr_path)} -> {new_hash}")
+
+
+def refresh_declared_fixed_outputs(*, cwd: Path, selected: list[str]) -> None:
+    records = nix_eval_json(REFRESHABLE_FIXED_OUTPUTS_ATTR, cwd=cwd)
+    if not isinstance(records, list):
+        raise SystemExit(f"{REFRESHABLE_FIXED_OUTPUTS_ATTR} must evaluate to a list")
+
+    selected_inputs = set(selected)
+    matching_records = [
+        record
+        for record in records
+        if isinstance(record, dict) and record.get("input") in selected_inputs
+    ]
+    if not matching_records:
+        return
+
+    print("Refreshing declared fixed-output hashes")
+    for record in matching_records:
+        update_declared_fixed_output(record, cwd=cwd)
+
+
 def run_refresh(
     *,
     cwd: Path,
@@ -182,6 +353,8 @@ def run_refresh(
 ) -> None:
     for name in selected:
         run("nix", "flake", "update", name, cwd=cwd)
+
+    refresh_declared_fixed_outputs(cwd=cwd, selected=selected)
 
     while True:
         if build_flake_target(build_target, cwd=cwd):

--- a/tests/test_refresh_flake_inputs.py
+++ b/tests/test_refresh_flake_inputs.py
@@ -1,6 +1,10 @@
+import contextlib
 import importlib.machinery
 import importlib.util
+import io
+import json
 import subprocess
+import tempfile
 import unittest
 from pathlib import Path
 from unittest.mock import patch
@@ -56,6 +60,8 @@ class RunRefreshTest(unittest.TestCase):
         def fake_run(*args, cwd, capture_output=False):
             if args == ("git", "diff", "--no-ext-diff", "--full-index"):
                 return subprocess.CompletedProcess(args, 0, stdout=diffs.pop(0))
+            if args == ("nix", "eval", "--json", ".#lib.refreshableFixedOutputs"):
+                return subprocess.CompletedProcess(args, 0, stdout="[]")
             updates.append((args, cwd, capture_output))
             return subprocess.CompletedProcess(args, 0)
 
@@ -70,7 +76,7 @@ class RunRefreshTest(unittest.TestCase):
             try:
                 module.run_refresh(
                     cwd=Path("/repo"),
-                    selected=["codex"],
+                    selected=["nixpkgs"],
                     build_target=".#homeConfigurations.coneill.activationPackage",
                     fix_hashes_command="determinate-nixd fix hashes --auto-apply",
                 )
@@ -82,7 +88,7 @@ class RunRefreshTest(unittest.TestCase):
         self.assertEqual(
             [
                 (
-                    ("nix", "flake", "update", "codex"),
+                    ("nix", "flake", "update", "nixpkgs"),
                     Path("/repo"),
                     False,
                 )
@@ -113,6 +119,8 @@ class RunRefreshTest(unittest.TestCase):
         def fake_run(*args, cwd, capture_output=False):
             if args == ("git", "diff", "--no-ext-diff", "--full-index"):
                 return subprocess.CompletedProcess(args, 0, stdout=diff)
+            if args == ("nix", "eval", "--json", ".#lib.refreshableFixedOutputs"):
+                return subprocess.CompletedProcess(args, 0, stdout="[]")
             return subprocess.CompletedProcess(args, 0)
 
         with (
@@ -126,12 +134,138 @@ class RunRefreshTest(unittest.TestCase):
             ):
                 module.run_refresh(
                     cwd=Path("/repo"),
-                    selected=["codex"],
+                    selected=["nixpkgs"],
                     build_target=".#homeConfigurations.coneill.activationPackage",
                     fix_hashes_command="determinate-nixd fix hashes --auto-apply",
                 )
 
         self.assertEqual(1, build_count)
+
+    def test_refreshes_declared_fixed_outputs_before_build(self):
+        module = load_script_module()
+        manifest = [
+            {
+                "input": "codex",
+                "file": "flake.nix",
+                "attrPath": ["rustyV8Archives", "aarch64-darwin", "hash"],
+                "url": "https://example.test/aarch64-darwin.tar.gz",
+                "hashType": "sha256",
+            },
+            {
+                "input": "codex",
+                "file": "flake.nix",
+                "attrPath": ["rustyV8Archives", "aarch64-linux", "hash"],
+                "url": "https://example.test/aarch64-linux.tar.gz",
+                "hashType": "sha256",
+            },
+            {
+                "input": "codex",
+                "file": "flake.nix",
+                "attrPath": ["rustyV8Archives", "x86_64-linux", "hash"],
+                "url": "https://example.test/x86_64-linux.tar.gz",
+                "hashType": "sha256",
+            },
+            {
+                "input": "nixpkgs",
+                "file": "flake.nix",
+                "attrPath": ["ignoredArchives", "x86_64-linux", "hash"],
+                "url": "https://example.test/ignored.tar.gz",
+                "hashType": "sha256",
+            },
+        ]
+        prefetch_hashes = {
+            "https://example.test/aarch64-darwin.tar.gz": "sha256-new-darwin",
+            "https://example.test/aarch64-linux.tar.gz": "sha256-new-arm",
+            "https://example.test/x86_64-linux.tar.gz": "sha256-new-x86",
+        }
+        flake_nix = """{
+  outputs = { self, nixpkgs }:
+    let
+      rustyV8Archives = {
+        aarch64-darwin = {
+          platform = "aarch64-apple-darwin";
+          hash = "sha256-old-darwin";
+        };
+        aarch64-linux = {
+          platform = "aarch64-unknown-linux-gnu";
+          hash = "sha256-old-arm";
+        };
+        x86_64-linux = {
+          platform = "x86_64-unknown-linux-gnu";
+          hash = "sha256-old-x86";
+        };
+      };
+      ignoredArchives = {
+        x86_64-linux = {
+          hash = "sha256-old-ignored";
+        };
+      };
+    in {};
+}
+"""
+
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo = Path(tempdir)
+            (repo / "flake.nix").write_text(flake_nix)
+            events = []
+
+            def fake_build(args, *, cwd, text):
+                events.append(("build", tuple(args)))
+                return subprocess.CompletedProcess(args, 0)
+
+            def fake_run(*args, cwd, capture_output=False):
+                events.append(("run", args))
+                if args == ("nix", "flake", "update", "codex"):
+                    return subprocess.CompletedProcess(args, 0)
+                if args == ("nix", "eval", "--json", ".#lib.refreshableFixedOutputs"):
+                    return subprocess.CompletedProcess(
+                        args,
+                        0,
+                        stdout=json.dumps(manifest),
+                    )
+                if args[:6] == (
+                    "nix",
+                    "store",
+                    "prefetch-file",
+                    "--json",
+                    "--hash-type",
+                    "sha256",
+                ):
+                    return subprocess.CompletedProcess(
+                        args,
+                        0,
+                        stdout=json.dumps({"hash": prefetch_hashes[args[6]]}),
+                    )
+                self.fail(f"unexpected command: {args}")
+
+            with (
+                patch.object(module.subprocess, "run", side_effect=fake_build),
+                patch.object(module, "run", side_effect=fake_run),
+                contextlib.redirect_stdout(io.StringIO()),
+            ):
+                module.run_refresh(
+                    cwd=repo,
+                    selected=["codex"],
+                    build_target=".#homeConfigurations.coneill.activationPackage",
+                    fix_hashes_command="determinate-nixd fix hashes --auto-apply",
+                )
+
+            updated_flake = (repo / "flake.nix").read_text()
+            self.assertIn('hash = "sha256-new-darwin";', updated_flake)
+            self.assertIn('hash = "sha256-new-arm";', updated_flake)
+            self.assertIn('hash = "sha256-new-x86";', updated_flake)
+            self.assertIn('hash = "sha256-old-ignored";', updated_flake)
+            build_index = next(
+                index for index, event in enumerate(events) if event[0] == "build"
+            )
+            prefetch_indexes = [
+                index
+                for index, event in enumerate(events)
+                if event[0] == "run"
+                and event[1][:3] == ("nix", "store", "prefetch-file")
+            ]
+            self.assertTrue(prefetch_indexes)
+            self.assertLess(max(prefetch_indexes), build_index)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Add a flake-declared manifest of refreshable fixed-output hashes and teach refresh-flake-inputs to prefetch and update matching records for changed inputs.

This keeps the workflow generic while allowing Codex's platform-specific rusty_v8 archives to be refreshed before the build/fix loop runs.
