### PR TITLE
Update Rusty V8 fixed-output hashes

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -39,15 +39,15 @@
       rustyV8Archives = {
         aarch64-darwin = {
           platform = "aarch64-apple-darwin";
-          hash = "sha256-v+LJvjKlbChUbw+WWCXuaPv2BkBfMQzE4XtEilaM+Yo=";
+          hash = "sha256-fnR0DD7woOj8DiaKJYYSPpg0D+lDVmjNwSiPrvtzYq4=";
         };
         aarch64-linux = {
           platform = "aarch64-unknown-linux-gnu";
-          hash = "sha256-2/FlsHyBvbBUvARrQ9I+afz3vMGkwbW0d2mDpxBi7Ng=";
+          hash = "sha256-lMPw/eAFFAT8obaR8opJbXjbgw58+0maBEyxpeOllFU=";
         };
         x86_64-linux = {
           platform = "x86_64-unknown-linux-gnu";
-          hash = "sha256-5ktNmeSuKTouhGJEqJuAF4uhA4LBP7WRwfppaPUpEVM=";
+          hash = "sha256-Cd3vbFEZKv/wVBExoO+cAPgxhdI5HaqxgDgqOr82rJU=";
         };
       };
       supportedSystems = builtins.attrNames rustyV8Archives;


### PR DESCRIPTION
## Summary
- refresh Rusty V8 archive hashes for Codex's v147.4.0 dependency
- replace the stale v146.4.0 fixed-output hashes for macOS arm64, Linux arm64, and Linux amd64

## Verification
- `nix eval --raw .#lib.codexV8Version`
- `nix eval --json .#lib.rustyV8Archives`
- `nix store prefetch-file --json --hash-type sha256` for all three v147.4.0 Rusty V8 archives
- `PYTHONDONTWRITEBYTECODE=1 python -m unittest discover -s tests`
- `git diff --check -- flake.nix`

Note: I also started a local `nix build --no-link --print-build-logs .#packages.aarch64-darwin.codex`; it progressed through the Rusty V8 compile without the previous fixed-output hash failure, but I interrupted it after it stayed quiet during the later Codex build/link phase.