### PR TITLE
Allow Nix fallback in flake builds

### DIFF
--- a/.github/workflows/flake-builds.yaml
+++ b/.github/workflows/flake-builds.yaml
@@ -103,6 +103,7 @@ jobs:
         nix_cores='${{ matrix.nix-cores }}'
         build_command=(
           nix build
+          --option fallback true
           --no-link
           --keep-going
           --print-out-paths


### PR DESCRIPTION
Enable Nix fallback for flake build jobs so CI can build from source when a binary substitute fails to import.

This keeps normal substituter behavior for healthy cache paths, but avoids hard-failing immediately on cache-side substitute hash/import failures like the Linux arm64 openapv issue seen on PR #81.