### PR TITLE
Clean up Bash shellcheck findings

### DIFF
--- a/.bash_profile
+++ b/.bash_profile
@@ -55,9 +55,9 @@ fi
 
 # Check if bash completion is available before sourcing
 if command_exists brew; then
-  if [[ -f $(brew --prefix)/etc/bash_completion ]]; then
+  if [[ -f "$(brew --prefix)/etc/bash_completion" ]]; then
     if command_exists complete; then
-      source $(brew --prefix)/etc/bash_completion
+      source "$(brew --prefix)/etc/bash_completion"
     else
       echo "Warning: bash completion not available - 'complete' command not found" >&2
     fi
@@ -67,18 +67,19 @@ fi
 if command_exists lsd; then
     alias ls=lsd
 else
-  if [ $MACOS ]; then
+  if [ "$MACOS" ]; then
     export CLICOLOR=1
     export LSCOLORS=ExFxCxDxBxegedabagacad
     if command_exists gls; then
-      eval $(gdircolors)
-      alias ls="gls --color=aut"
+      eval "$(gdircolors)"
+      alias ls="gls --color=auto"
     fi
   fi
 fi
 
 if command_exists vim; then
-    export EDITOR=$(type -p vim)
+    EDITOR=$(type -p vim)
+    export EDITOR
     export GIT_EDITOR=$EDITOR
 fi
 

--- a/.bashrc
+++ b/.bashrc
@@ -45,12 +45,15 @@ pc_lred="\[$(tput setaf 9)\]"
 pc_reset="\[$(tput sgr0)\]"
 
 # inline flake name
+# shellcheck disable=SC2016
 flake_segment='${FLAKE_NAME:+${FLAKE_NAME}❄️}'
 
 # inline conditional user (shown if not coneill, claytono, or codespace)
+# shellcheck disable=SC2016
 user_segment='$( [[ $USER != "coneill" && $USER != "claytono" && $USER != "codespace" ]] && echo "'$pc_lred'\u'$pc_reset'@" )'
 
 # inline git branch
+# shellcheck disable=SC2016
 git_branch_segment='$(b=$(git rev-parse --abbrev-ref HEAD 2>/dev/null); [[ -n "$b" ]] && echo "'$pc_lred' ($b)'$pc_reset'")'
 
 # final prompt string
@@ -65,7 +68,7 @@ if command_exists direnv; then
   # Claude Code runs each command in a new shell, so we need to explicitly
   # export direnv environment on shell startup (not just on prompt)
   if [ -n "$CLAUDECODE" ]; then
-    eval "$(DIRENV_LOG_FORMAT= direnv export bash)"
+    eval "$(DIRENV_LOG_FORMAT='' direnv export bash)"
   fi
 fi
 


### PR DESCRIPTION
Quote command substitutions and variable expansions in Bash startup files.

Document intentional delayed expansion in prompt fragments and make the direnv log-format assignment explicit so shellcheck passes without changing startup behavior.
