### PR TITLE
Fix Bash login guard inheritance

### DIFF
--- a/.bash_profile
+++ b/.bash_profile
@@ -95,13 +95,8 @@ if [ -d /nix/var/nix/profiles/default/bin ]; then
   move_to_front /nix/var/nix/profiles/default/bin
 fi
 
-# check if this is a login and/or interactive shell
-# Use shopt instead of $0 check - works with both -bash and bash -l
-shopt -q login_shell && export LOGIN_BASH="1"
-[[ "$-" == *i* ]] && export INTERACTIVE_BASH="1"
-
 # run bashrc if this is a login, interactive shell
-if [ -n "$LOGIN_BASH" ] && [ -n "$INTERACTIVE_BASH" ]; then
+if shopt -q login_shell && [[ "$-" == *i* ]]; then
   source ~/.bashrc
 fi
 

--- a/.bashrc
+++ b/.bashrc
@@ -1,11 +1,9 @@
 # shellcheck shell=bash
 
-# check if this is a login shell
-# Use shopt instead of $0 check - works with both -bash and bash -l
-shopt -q login_shell && export LOGIN_BASH="1"
-
 # run bash_profile if this is not a login shell
-[ -z "$LOGIN_BASH" ] && source ~/.bash_profile
+if ! shopt -q login_shell; then
+  source ~/.bash_profile
+fi
 
 if [ -n "${GHOSTTY_RESOURCES_DIR}" ] && [ -f "${GHOSTTY_RESOURCES_DIR}/shell-integration/bash/ghostty.bash" ]; then
   builtin source "${GHOSTTY_RESOURCES_DIR}/shell-integration/bash/ghostty.bash"


### PR DESCRIPTION
Recompute login and interactive shell state from the current Bash process instead of relying on exported LOGIN_BASH and INTERACTIVE_BASH values.

This preserves the .bash_profile/.bashrc handoff while allowing child non-login shells, such as Zellij panes, to load the direnv hook.
