### PR TITLE
Adjust Codex Renovate policy

### DIFF
--- a/.renovaterc
+++ b/.renovaterc
@@ -35,6 +35,25 @@
   "packageRules": [
     {
       "matchManagers": [
+        "custom.regex"
+      ],
+      "matchDatasources": [
+        "github-tags"
+      ],
+      "matchDepNames": [
+        "openai/codex"
+      ],
+      "minimumReleaseAge": "2 days",
+      "automerge": true,
+      "automergeType": "pr",
+      "addLabels": [
+        "nix",
+        "automerge"
+      ],
+      "description": "Auto-merge Codex updates after a two-day release-age delay"
+    },
+    {
+      "matchManagers": [
         "pre-commit"
       ],
       "automerge": true,


### PR DESCRIPTION
## Summary
- add a Codex-specific Renovate package rule
- reduce Codex release-age delay to 2 days
- enable PR automerge and add nix/automerge labels for Codex updates

## Verification
- jq . .renovaterc
- npx --yes --package renovate renovate-config-validator .renovaterc
- nix develop --command pre-commit run --files .renovaterc
- git diff --check
- commit hooks