### PR TITLE
Remove zellij Ctrl-q shortcut

### DIFF
--- a/.config/zellij/config.kdl
+++ b/.config/zellij/config.kdl
@@ -165,7 +165,6 @@ keybinds clear-defaults=true {
         bind "Alt o" { MoveTab "right"; }
         bind "Alt p" { TogglePaneInGroup; }
         bind "Alt Shift p" { ToggleGroupMarking; }
-        bind "Ctrl q" { Quit; }
     }
     shared_except "locked" "move" {
         bind "Ctrl h" { SwitchToMode "move"; }


### PR DESCRIPTION
Remove the shared Ctrl-q binding so zellij no longer quits from that shortcut.
