### PR TITLE
Manage cco wrapper scripts

### DIFF
--- a/home.nix
+++ b/home.nix
@@ -158,6 +158,22 @@ in {
   home.file.".bashrc".source = config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/src/dotfiles/.bashrc";
   home.file.".tmux.conf".source = config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/src/dotfiles/.tmux.conf";
   home.file."bin/ssh-known-hosts-update".source = config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/src/dotfiles/scripts/ssh-known-hosts-update";
+  home.file."bin/cco-claude" = {
+    source = config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/src/dotfiles/scripts/cco-claude";
+    force = true;
+  };
+  home.file."bin/cco-codex" = {
+    source = config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/src/dotfiles/scripts/cco-claude";
+    force = true;
+  };
+  home.file."bin/cco-opencode" = {
+    source = config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/src/dotfiles/scripts/cco-claude";
+    force = true;
+  };
+  home.file."bin/cco-claude-safe" = {
+    source = config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/src/dotfiles/scripts/cco-claude-safe";
+    force = true;
+  };
 
   home.packages = with pkgs; [
     argocd

--- a/scripts/cco-claude
+++ b/scripts/cco-claude
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+set -e
+
+name=$(basename "$0")
+mode_args=()
+common_args=(
+  --allow-keychain
+  --add-dir ~/.plannotator:rw
+  --add-dir ~/.cache/nix:rw
+  --add-dir ~/.cache/pre-commit:rw
+  --add-dir ~/.cache/uv:rw
+  --add-dir ~/.npm:rw
+  --add-dir ~/.bun:rw
+  --add-dir ~/.gnupg:rw
+  --add-dir ~/.docker:rw
+  --add-dir ~/.ansible:rw
+  --add-dir ~/.config/superpowers:rw
+  --add-dir ~/.codex:rw
+  --add-dir ~/.local/share/uv:rw
+  --add-dir ~/.memex:rw
+)
+cco_args=("${common_args[@]}")
+wrapped_args=()
+
+case "$name" in
+  cco-claude)
+    mode_args=(--allow-dangerously-skip-permissions)
+    ;;
+  cco-opencode)
+    mode_args=(opencode)
+    export OPENCODE_ENABLE_EXA=1
+    ;;
+  cco-codex)
+    mode_args=(codex --dangerously-bypass-approvals-and-sandbox)
+    ;;
+  *)
+    echo "Unsupported wrapper name: $name" >&2
+    exit 1
+    ;;
+esac
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --add-dir=*)
+      cco_args+=("$1")
+      shift
+      ;;
+    --add-dir)
+      if [[ $# -lt 2 ]]; then
+        echo "--add-dir requires an argument" >&2
+        exit 1
+      fi
+      cco_args+=("$1" "$2")
+      shift 2
+      ;;
+    *)
+      wrapped_args+=("$1")
+      shift
+      ;;
+  esac
+done
+
+exec cco "${cco_args[@]}" "${mode_args[@]}" "${wrapped_args[@]}"

--- a/scripts/cco-claude-safe
+++ b/scripts/cco-claude-safe
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+set -e
+
+cco_args=(
+  --command claude
+  --add-dir ~/.plannotator:rw
+  --add-dir ~/.cache/nix:rw
+  --add-dir ~/.cache/pre-commit:rw
+  --add-dir ~/.cache/uv:rw
+  --add-dir ~/.npm:rw
+  --add-dir ~/.gnupg:rw
+  --add-dir ~/.docker:rw
+  --add-dir ~/.ansible:rw
+)
+wrapped_args=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --add-dir=*)
+      cco_args+=("$1")
+      shift
+      ;;
+    --add-dir)
+      if [[ $# -lt 2 ]]; then
+        echo "--add-dir requires an argument" >&2
+        exit 1
+      fi
+      cco_args+=("$1" "$2")
+      shift 2
+      ;;
+    *)
+      wrapped_args+=("$1")
+      shift
+      ;;
+  esac
+done
+
+exec cco "${cco_args[@]}" "${wrapped_args[@]}"


### PR DESCRIPTION
Move cco wrapper scripts into the dotfiles repo so Home Manager owns the ~/bin entries.

Route wrapper-level --add-dir flags into cco before invoking the wrapped CLI.
