### PR TITLE
Install renovate-eval from source checkout

### DIFF
--- a/home.nix
+++ b/home.nix
@@ -156,6 +156,9 @@ in {
 
   home.file.".bash_profile".source = config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/src/dotfiles/.bash_profile";
   home.file.".bashrc".source = config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/src/dotfiles/.bashrc";
+  home.file.".codex/skills/renovate-eval" = {
+    source = config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/src/github-actions/renovate-eval";
+  };
   home.file.".tmux.conf".source = config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/src/dotfiles/.tmux.conf";
   home.file."bin/ssh-known-hosts-update".source = config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/src/dotfiles/scripts/ssh-known-hosts-update";
   home.file."bin/cco-claude" = {


### PR DESCRIPTION
Manage the Codex skill as an out-of-store symlink to the renovate-eval directory in the github-actions checkout.
