### PR TITLE
Add weekly npm cache cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.swp
 .vscode
 .vagrant
+.tmp
 
 # Python
 __pycache__/

--- a/config/dagu/dags/cleanup-npm.yaml
+++ b/config/dagu/dags/cleanup-npm.yaml
@@ -1,0 +1,9 @@
+---
+schedule: 0 8 * * 0
+queue: cleanup
+steps:
+- id: clean_package_cache
+  command: npm cache clean --force
+
+- id: clean_npx_cache
+  command: npm cache npx rm --force


### PR DESCRIPTION
npm and npx caches grow without an automatic size bound, while repo-local scratch directories should not appear as untracked work. Add a weekly Dagu cleanup job using npm’s supported commands and ignore the repository .tmp directory.
