### PR TITLE
Load Bash completion only interactively

### DIFF
--- a/.Brewfile
+++ b/.Brewfile
@@ -84,7 +84,7 @@ if macos?
   brew "awscli"
   brew "azure-cli"
   brew "bash"
-  brew "bash-completion"
+  brew "bash-completion@2"
   brew "codeowners"
   brew "coreutils"
   brew "curl"

--- a/.bash_profile
+++ b/.bash_profile
@@ -53,11 +53,11 @@ if [ -d "${HOME}/.krew/bin" ]; then
   pathmunge "${HOME}/.krew/bin" after
 fi
 
-# Check if bash completion is available before sourcing
-if command_exists brew; then
-  if [[ -f "$(brew --prefix)/etc/bash_completion" ]]; then
+# Only load bash completion in interactive shells
+if [[ $- == *i* ]] && command_exists brew; then
+  if [[ -f "$(brew --prefix)/etc/profile.d/bash_completion.sh" ]]; then
     if command_exists complete; then
-      source "$(brew --prefix)/etc/bash_completion"
+      source "$(brew --prefix)/etc/profile.d/bash_completion.sh"
     else
       echo "Warning: bash completion not available - 'complete' command not found" >&2
     fi


### PR DESCRIPTION
The legacy Homebrew completion path disappears when moving to bash-completion@2, and loading completion functions in non-interactive shells also exposes extglob syntax that Codex cannot replay in shell snapshots. Use the v2 profile initializer only for interactive Bash sessions so tab completion remains available without polluting automation shells.
