### PR TITLE
Manage memex with Nix

### DIFF
--- a/.github/workflows/flake-builds.yaml
+++ b/.github/workflows/flake-builds.yaml
@@ -27,14 +27,14 @@ jobs:
           runs-on: ubuntu-24.04-arm
           flake-output: .#homeConfigurations.coneill-aarch64-linux.activationPackage
           codex-output: .#packages.aarch64-linux.codex
-          memex-output: .#packages.aarch64-linux.memex
+          memex-output: ''
           nix-cores: '1'
           extra-swap-size-gb: '8'
         - label: home-manager (linux amd64)
           runs-on: ubuntu-24.04
           flake-output: .#homeConfigurations.coneill-x86_64-linux.activationPackage
           codex-output: .#packages.x86_64-linux.codex
-          memex-output: .#packages.x86_64-linux.memex
+          memex-output: ''
           nix-cores: ''
           extra-swap-size-gb: ''
 
@@ -116,7 +116,10 @@ jobs:
         if [ -n "$nix_cores" ]; then
           build_command+=(--cores "$nix_cores")
         fi
-        build_command+=("$flake_output" "$codex_output" "$memex_output")
+        build_command+=("$flake_output" "$codex_output")
+        if [ -n "$memex_output" ]; then
+          build_command+=("$memex_output")
+        fi
 
         build_output=/tmp/flake-build-output
         output_paths=/tmp/flake-output-paths
@@ -141,6 +144,12 @@ jobs:
         set -e
 
         awk '/^\/nix\/store\// { print }' "$build_output" > "$output_paths"
+
+        if [ "$build_status" -eq 0 ] && [ -n "$memex_output" ]; then
+          memex_path=$(nix path-info "$memex_output")
+          "$memex_path/bin/memex" --version
+        fi
+
         exit "$build_status"
 
     - name: Push flake closure to Cachix

--- a/.github/workflows/flake-builds.yaml
+++ b/.github/workflows/flake-builds.yaml
@@ -20,18 +20,21 @@ jobs:
           runs-on: macos-26
           flake-output: .#homeConfigurations.coneill-aarch64-darwin.activationPackage
           codex-output: .#packages.aarch64-darwin.codex
+          memex-output: .#packages.aarch64-darwin.memex
           nix-cores: ''
           extra-swap-size-gb: ''
         - label: home-manager (linux arm64)
           runs-on: ubuntu-24.04-arm
           flake-output: .#homeConfigurations.coneill-aarch64-linux.activationPackage
           codex-output: .#packages.aarch64-linux.codex
+          memex-output: .#packages.aarch64-linux.memex
           nix-cores: '1'
           extra-swap-size-gb: '8'
         - label: home-manager (linux amd64)
           runs-on: ubuntu-24.04
           flake-output: .#homeConfigurations.coneill-x86_64-linux.activationPackage
           codex-output: .#packages.x86_64-linux.codex
+          memex-output: .#packages.x86_64-linux.memex
           nix-cores: ''
           extra-swap-size-gb: ''
 
@@ -100,6 +103,7 @@ jobs:
 
         flake_output='${{ matrix.flake-output }}'
         codex_output='${{ matrix.codex-output }}'
+        memex_output='${{ matrix.memex-output }}'
         nix_cores='${{ matrix.nix-cores }}'
         build_command=(
           nix build
@@ -112,7 +116,7 @@ jobs:
         if [ -n "$nix_cores" ]; then
           build_command+=(--cores "$nix_cores")
         fi
-        build_command+=("$flake_output" "$codex_output")
+        build_command+=("$flake_output" "$codex_output" "$memex_output")
 
         build_output=/tmp/flake-build-output
         output_paths=/tmp/flake-output-paths

--- a/.renovaterc
+++ b/.renovaterc
@@ -30,6 +30,18 @@
       "depNameTemplate": "openai/codex",
       "datasourceTemplate": "github-tags",
       "versioningTemplate": "regex:^rust-v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/^flake\\.nix$/"
+      ],
+      "matchStrings": [
+        "memex\\s*=\\s*\\{\\s*url\\s*=\\s*\"github:nicosuave/memex\\?ref=(?<currentValue>v\\d+\\.\\d+\\.\\d+)\";"
+      ],
+      "depNameTemplate": "nicosuave/memex",
+      "datasourceTemplate": "github-releases",
+      "versioningTemplate": "semver"
     }
   ],
   "packageRules": [
@@ -51,6 +63,23 @@
         "automerge"
       ],
       "description": "Auto-merge Codex updates after a two-day release-age delay"
+    },
+    {
+      "matchManagers": [
+        "custom.regex"
+      ],
+      "matchDatasources": [
+        "github-releases"
+      ],
+      "matchDepNames": [
+        "nicosuave/memex"
+      ],
+      "minimumReleaseAge": "14 days",
+      "automerge": false,
+      "addLabels": [
+        "nix"
+      ],
+      "description": "Require review of memex releases after a 14-day release-age delay"
     },
     {
       "matchManagers": [

--- a/flake-versions.yaml
+++ b/flake-versions.yaml
@@ -32,6 +32,7 @@ kubernetes-helm: 4.2.4
 lftp: 4.9.3
 lsd: 1.2.0
 man-db: 2.13.1
+memex: 0.11.6
 mtr: '0.96'
 nix-search-cli: 0.3-unstable-2025-12-03
 nmap: '7.991'

--- a/flake.lock
+++ b/flake.lock
@@ -89,6 +89,23 @@
         "type": "github"
       }
     },
+    "memex": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1787287552,
+        "narHash": "sha256-sFefGAYzG86ZO9E/eQfgQ8PeMGt2jGVlIuYOjHYbMZ0=",
+        "owner": "nicosuave",
+        "repo": "memex",
+        "rev": "9176bb0e2c88e5013346526c0a9750d87ee7641c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nicosuave",
+        "ref": "v0.11.6",
+        "repo": "memex",
+        "type": "github"
+      }
+    },
     "nix-filter": {
       "locked": {
         "lastModified": 1710156097,
@@ -207,6 +224,7 @@
       "inputs": {
         "codex": "codex",
         "home-manager": "home-manager",
+        "memex": "memex",
         "nix-search-cli": "nix-search-cli",
         "nixpkgs": "nixpkgs_3",
         "strace-macos": "strace-macos"

--- a/flake.nix
+++ b/flake.nix
@@ -5,6 +5,11 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     codex.url = "github:openai/codex?ref=rust-v0.147.0";
 
+    memex = {
+      url = "github:nicosuave/memex?ref=v0.11.6";
+      flake = false;
+    };
+
     home-manager = {
       url = "github:nix-community/home-manager";
       inputs.nixpkgs.follows = "nixpkgs";
@@ -21,7 +26,7 @@
     };
   };
 
-  outputs = { self, nixpkgs, codex, home-manager, nix-search-cli, strace-macos }:
+  outputs = { self, nixpkgs, codex, memex, home-manager, nix-search-cli, strace-macos }:
     let
       pkgsFor = system: nixpkgs.legacyPackages.${system};
       codexSource = codex.outPath;
@@ -42,9 +47,27 @@
           hash = "sha256-vXWNU9VuQdxl4EX0WJ33mgOO0ZegEa3LUqJY5q1kz9o=";
         };
       };
+      memexSource = memex;
+      memexVersion =
+        (builtins.fromTOML (builtins.readFile (memexSource + "/Cargo.toml")))
+        .package.version;
+      memexReleasePackages = {
+        aarch64-darwin = {
+          asset = "macos-arm64";
+          hash = "sha256-II3dIHNjVlGvL+kAdAAC9628bS8IXlwMSV3/GeTIU5U=";
+        };
+        aarch64-linux = {
+          asset = "linux-arm64";
+          hash = "sha256-9kfv+rRLAIiIloqKvY6tAi8t//8AnNzbVhZtenzaVIc=";
+        };
+        x86_64-linux = {
+          asset = "linux-x86_64";
+          hash = "sha256-h9KTmigm5u5XP2sPoeQ9xzUQOjIHjzEpNZ8ZKVFjBzc=";
+        };
+      };
       supportedSystems = builtins.attrNames codexReleasePackages;
       forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
-      refreshableFixedOutputs = map (system:
+      codexFixedOutputs = map (system:
         let release = codexReleasePackages.${system};
         in {
           input = "codex";
@@ -53,6 +76,16 @@
           url = "https://github.com/openai/codex/releases/download/rust-v${codexVersion}/codex-package-${release.target}.tar.gz";
           hashType = "sha256";
         }) supportedSystems;
+      memexFixedOutputs = map (system:
+        let release = memexReleasePackages.${system};
+        in {
+          input = "memex";
+          file = "flake.nix";
+          attrPath = [ "memexReleasePackages" system "hash" ];
+          url = "https://github.com/nicosuave/memex/releases/download/v${memexVersion}/memex-${memexVersion}-${release.asset}.tar.gz";
+          hashType = "sha256";
+        }) supportedSystems;
+      refreshableFixedOutputs = codexFixedOutputs ++ memexFixedOutputs;
       codexPackage = {
         fetchurl,
         lib,
@@ -110,13 +143,59 @@
         });
       codexPkgFor = system: (pkgsFor system).callPackage codexPackage {
       };
+      memexPackage = {
+        fetchurl,
+        lib,
+        stdenvNoCC,
+        versionCheckHook,
+        ...
+      }:
+        let release = memexReleasePackages.${stdenvNoCC.hostPlatform.system};
+        in stdenvNoCC.mkDerivation (finalAttrs: {
+          pname = "memex";
+          version = memexVersion;
+
+          src = fetchurl {
+            url = "https://github.com/nicosuave/memex/releases/download/v${finalAttrs.version}/memex-${finalAttrs.version}-${release.asset}.tar.gz";
+            hash = release.hash;
+          };
+          sourceRoot = ".";
+
+          dontConfigure = true;
+          dontBuild = true;
+
+          installPhase = ''
+            runHook preInstall
+
+            install -Dm755 memex $out/bin/memex
+
+            runHook postInstall
+          '';
+
+          doInstallCheck = true;
+          nativeInstallCheckInputs = [ versionCheckHook ];
+
+          meta = {
+            description = "Fast local history search for local agent logs";
+            homepage = "https://github.com/nicosuave/memex";
+            license = lib.licenses.mit;
+            mainProgram = "memex";
+            platforms = supportedSystems;
+          };
+        });
+      memexPkgFor = system: (pkgsFor system).callPackage memexPackage {
+      };
       homeConfigurationFor = system:
         home-manager.lib.homeManagerConfiguration {
           pkgs = pkgsFor system;
-          modules = [ ./home.nix ];
+          modules = [
+            (memexSource + "/nix/hm-module.nix")
+            ./home.nix
+          ];
           extraSpecialArgs = {
-            inherit nix-search-cli strace-macos;
+            inherit memexSource nix-search-cli strace-macos;
             codexPkg = codexPkgFor system;
+            memexPkg = memexPkgFor system;
           };
         };
       systemHomeConfigurations =
@@ -126,11 +205,12 @@
         }) supportedSystems);
     in {
       lib = {
-        inherit codexReleasePackages refreshableFixedOutputs supportedSystems;
+        inherit codexReleasePackages memexReleasePackages memexSource refreshableFixedOutputs supportedSystems;
       };
 
       packages = forAllSystems (system: {
         codex = codexPkgFor system;
+        memex = memexPkgFor system;
         default = codexPkgFor system;
       });
 

--- a/flake.nix
+++ b/flake.nix
@@ -56,16 +56,9 @@
           asset = "macos-arm64";
           hash = "sha256-II3dIHNjVlGvL+kAdAAC9628bS8IXlwMSV3/GeTIU5U=";
         };
-        aarch64-linux = {
-          asset = "linux-arm64";
-          hash = "sha256-9kfv+rRLAIiIloqKvY6tAi8t//8AnNzbVhZtenzaVIc=";
-        };
-        x86_64-linux = {
-          asset = "linux-x86_64";
-          hash = "sha256-h9KTmigm5u5XP2sPoeQ9xzUQOjIHjzEpNZ8ZKVFjBzc=";
-        };
       };
       supportedSystems = builtins.attrNames codexReleasePackages;
+      memexSystems = builtins.attrNames memexReleasePackages;
       forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
       codexFixedOutputs = map (system:
         let release = codexReleasePackages.${system};
@@ -84,7 +77,7 @@
           attrPath = [ "memexReleasePackages" system "hash" ];
           url = "https://github.com/nicosuave/memex/releases/download/v${memexVersion}/memex-${memexVersion}-${release.asset}.tar.gz";
           hashType = "sha256";
-        }) supportedSystems;
+        }) memexSystems;
       refreshableFixedOutputs = codexFixedOutputs ++ memexFixedOutputs;
       codexPackage = {
         fetchurl,
@@ -180,7 +173,7 @@
             homepage = "https://github.com/nicosuave/memex";
             license = lib.licenses.mit;
             mainProgram = "memex";
-            platforms = supportedSystems;
+            platforms = memexSystems;
           };
         });
       memexPkgFor = system: (pkgsFor system).callPackage memexPackage {
@@ -195,7 +188,7 @@
           extraSpecialArgs = {
             inherit memexSource nix-search-cli strace-macos;
             codexPkg = codexPkgFor system;
-            memexPkg = memexPkgFor system;
+            memexPkg = if builtins.hasAttr system memexReleasePackages then memexPkgFor system else null;
           };
         };
       systemHomeConfigurations =
@@ -208,11 +201,14 @@
         inherit codexReleasePackages memexReleasePackages memexSource refreshableFixedOutputs supportedSystems;
       };
 
-      packages = forAllSystems (system: {
-        codex = codexPkgFor system;
-        memex = memexPkgFor system;
-        default = codexPkgFor system;
-      });
+      packages = forAllSystems (system:
+        {
+          codex = codexPkgFor system;
+          default = codexPkgFor system;
+        }
+        // nixpkgs.lib.optionalAttrs (builtins.hasAttr system memexReleasePackages) {
+          memex = memexPkgFor system;
+        });
 
       homeConfigurations = systemHomeConfigurations // {
         coneill = systemHomeConfigurations.coneill-aarch64-darwin;

--- a/home.nix
+++ b/home.nix
@@ -2,7 +2,8 @@
 
 let
   username = "coneill";
-  homeDirectory = if pkgs.stdenv.isDarwin then "/Users/${username}" else "/home/${username}";
+  homeDirectory = if pkgs.stdenv.hostPlatform.isDarwin then "/Users/${username}" else "/home/${username}";
+  memexPollInterval = 300;
 
   launchdPath = packages:
     lib.concatStringsSep ":" (
@@ -107,7 +108,7 @@ in {
 
   programs.home-manager.enable = true;
 
-  programs.memex = {
+  programs.memex = lib.mkIf pkgs.stdenv.hostPlatform.isDarwin {
     enable = true;
     package = memexPkg;
     settings = {
@@ -116,10 +117,8 @@ in {
       execution_provider = "cpu";
       auto_index_on_search = false;
       index_service_mode = "continuous";
-      index_service_poll_interval = 300;
-    } // lib.optionalAttrs pkgs.stdenv.isDarwin {
-      index_service_label = "com.memex.index";
-      index_service_plist = "${homeDirectory}/Library/LaunchAgents/com.memex.index.plist";
+      index_service_poll_interval = memexPollInterval;
+      index_service_plist = "${config.home.homeDirectory}/Library/LaunchAgents/com.memex.index.plist";
     };
   };
 
@@ -128,7 +127,7 @@ in {
 
     signing = {
       key = "clayton@oneill.net";
-      signByDefault = pkgs.stdenv.isDarwin;
+      signByDefault = pkgs.stdenv.hostPlatform.isDarwin;
       format = "openpgp";
     };
 
@@ -161,7 +160,7 @@ in {
       init.defaultBranch = "main";
       pull.rebase = true;
       "url \"git@github.com:\"".pushInsteadOf = "https://github.com/";
-    } // lib.optionalAttrs pkgs.stdenv.isDarwin {
+    } // lib.optionalAttrs pkgs.stdenv.hostPlatform.isDarwin {
       credential.helper = "osxkeychain";
     };
   };
@@ -172,15 +171,17 @@ in {
 
   home.file.".bash_profile".source = config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/src/dotfiles/.bash_profile";
   home.file.".bashrc".source = config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/src/dotfiles/.bashrc";
-  home.file.".agents/skills/memex-search" = {
+  home.file.".agents/skills/memex-search" = lib.mkIf pkgs.stdenv.hostPlatform.isDarwin {
     source = memexSource + "/skills/memex-search";
     force = true;
   };
-  home.file.".claude/skills/memex-search" = {
+  home.file.".claude/skills/memex-search" = lib.mkIf pkgs.stdenv.hostPlatform.isDarwin {
     source = memexSource + "/skills/memex-search";
     force = true;
   };
-  home.file.".memex/config.toml".force = true;
+  home.file.".memex/config.toml" = lib.mkIf pkgs.stdenv.hostPlatform.isDarwin {
+    force = true;
+  };
   home.file.".codex/skills/renovate-eval" = {
     source = config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/src/github-actions/renovate-eval";
   };
@@ -259,14 +260,14 @@ in {
     yq-go
     yt-dlp
     zellij
-  ] ++ lib.optionals pkgs.stdenv.isDarwin [
+  ] ++ lib.optionals pkgs.stdenv.hostPlatform.isDarwin [
     watch-only
     coreutils-partial
     ts-only
     dagu
   ];
 
-  launchd.agents.dagu = lib.mkIf pkgs.stdenv.isDarwin {
+  launchd.agents.dagu = lib.mkIf pkgs.stdenv.hostPlatform.isDarwin {
     enable = true;
     config = {
       ProgramArguments = [
@@ -288,7 +289,7 @@ in {
     };
   };
 
-  launchd.agents."node-exporter" = lib.mkIf pkgs.stdenv.isDarwin {
+  launchd.agents."node-exporter" = lib.mkIf pkgs.stdenv.hostPlatform.isDarwin {
     enable = true;
     config = {
       ProgramArguments = [
@@ -308,7 +309,7 @@ in {
     };
   };
 
-  launchd.agents.memex = lib.mkIf pkgs.stdenv.isDarwin {
+  launchd.agents.memex = lib.mkIf pkgs.stdenv.hostPlatform.isDarwin {
     enable = true;
     config = {
       Label = "com.memex.index";
@@ -317,21 +318,22 @@ in {
         "index"
         "--watch"
         "--watch-interval"
-        "300"
+        (toString memexPollInterval)
       ];
       EnvironmentVariables = launchdEnvironment { };
       KeepAlive = true;
       RunAtLoad = true;
+      WorkingDirectory = config.home.homeDirectory;
       StandardOutPath = "${config.home.homeDirectory}/.memex/index-service.log";
       StandardErrorPath = "${config.home.homeDirectory}/.memex/index-service.err.log";
     };
   };
 
-  home.activation.daguDataDir = lib.mkIf pkgs.stdenv.isDarwin (lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+  home.activation.daguDataDir = lib.mkIf pkgs.stdenv.hostPlatform.isDarwin (lib.hm.dag.entryAfter [ "writeBoundary" ] ''
     mkdir -p "${config.home.homeDirectory}/.local/share/dagu"
   '');
 
-  home.activation.prometheusExportersDataDir = lib.mkIf pkgs.stdenv.isDarwin (lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+  home.activation.prometheusExportersDataDir = lib.mkIf pkgs.stdenv.hostPlatform.isDarwin (lib.hm.dag.entryAfter [ "writeBoundary" ] ''
     mkdir -p "${config.home.homeDirectory}/.local/share/prometheus-exporters"
   '');
 }

--- a/home.nix
+++ b/home.nix
@@ -1,4 +1,4 @@
-{ config, pkgs, lib, codexPkg, ... }:
+{ config, pkgs, lib, codexPkg, memexPkg, memexSource, ... }:
 
 let
   username = "coneill";
@@ -107,6 +107,22 @@ in {
 
   programs.home-manager.enable = true;
 
+  programs.memex = {
+    enable = true;
+    package = memexPkg;
+    settings = {
+      embeddings = true;
+      model = "gemma";
+      execution_provider = "cpu";
+      auto_index_on_search = false;
+      index_service_mode = "continuous";
+      index_service_poll_interval = 300;
+    } // lib.optionalAttrs pkgs.stdenv.isDarwin {
+      index_service_label = "com.memex.index";
+      index_service_plist = "${homeDirectory}/Library/LaunchAgents/com.memex.index.plist";
+    };
+  };
+
   programs.git = {
     enable = true;
 
@@ -156,6 +172,15 @@ in {
 
   home.file.".bash_profile".source = config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/src/dotfiles/.bash_profile";
   home.file.".bashrc".source = config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/src/dotfiles/.bashrc";
+  home.file.".agents/skills/memex-search" = {
+    source = memexSource + "/skills/memex-search";
+    force = true;
+  };
+  home.file.".claude/skills/memex-search" = {
+    source = memexSource + "/skills/memex-search";
+    force = true;
+  };
+  home.file.".memex/config.toml".force = true;
   home.file.".codex/skills/renovate-eval" = {
     source = config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/src/github-actions/renovate-eval";
   };
@@ -280,6 +305,25 @@ in {
       RunAtLoad = true;
       StandardOutPath = "${config.home.homeDirectory}/.local/share/prometheus-exporters/node-exporter.stdout.log";
       StandardErrorPath = "${config.home.homeDirectory}/.local/share/prometheus-exporters/node-exporter.stderr.log";
+    };
+  };
+
+  launchd.agents.memex = lib.mkIf pkgs.stdenv.isDarwin {
+    enable = true;
+    config = {
+      Label = "com.memex.index";
+      ProgramArguments = [
+        "${memexPkg}/bin/memex"
+        "index"
+        "--watch"
+        "--watch-interval"
+        "300"
+      ];
+      EnvironmentVariables = launchdEnvironment { };
+      KeepAlive = true;
+      RunAtLoad = true;
+      StandardOutPath = "${config.home.homeDirectory}/.memex/index-service.log";
+      StandardErrorPath = "${config.home.homeDirectory}/.memex/index-service.err.log";
     };
   };
 

--- a/tests/test_refresh_flake_inputs.py
+++ b/tests/test_refresh_flake_inputs.py
@@ -268,7 +268,7 @@ class RunRefreshTest(unittest.TestCase):
             self.assertLess(max(prefetch_indexes), build_index)
 
 
-class FlakeCodexPackagingTest(unittest.TestCase):
+class FlakeReleasePackagingTest(unittest.TestCase):
     def test_codex_refresh_manifest_tracks_release_packages(self):
         result = subprocess.run(
             ["nix", "eval", "--json", ".#lib.refreshableFixedOutputs"],
@@ -291,6 +291,37 @@ class FlakeCodexPackagingTest(unittest.TestCase):
                 record["url"],
             )
             self.assertTrue(record["url"].endswith(".tar.gz"))
+
+    def test_memex_refresh_manifest_tracks_release_packages(self):
+        result = subprocess.run(
+            ["nix", "eval", "--json", ".#lib.refreshableFixedOutputs"],
+            cwd=SCRIPT_PATH.parent.parent,
+            check=True,
+            text=True,
+            capture_output=True,
+        )
+        records = json.loads(result.stdout)
+        memex_records = [record for record in records if record.get("input") == "memex"]
+
+        expected_assets = {
+            "aarch64-darwin": "macos-arm64",
+            "aarch64-linux": "linux-arm64",
+            "x86_64-linux": "linux-x86_64",
+        }
+        self.assertEqual(3, len(memex_records))
+        self.assertEqual(
+            set(expected_assets), {record["attrPath"][1] for record in memex_records}
+        )
+        for record in memex_records:
+            system = record["attrPath"][1]
+            self.assertEqual("flake.nix", record["file"])
+            self.assertEqual("sha256", record["hashType"])
+            self.assertEqual("memexReleasePackages", record["attrPath"][0])
+            self.assertEqual("hash", record["attrPath"][-1])
+            self.assertIn("/nicosuave/memex/releases/download/v", record["url"])
+            self.assertTrue(
+                record["url"].endswith(f"-{expected_assets[system]}.tar.gz")
+            )
 
 
 if __name__ == "__main__":

--- a/tests/test_refresh_flake_inputs.py
+++ b/tests/test_refresh_flake_inputs.py
@@ -9,7 +9,6 @@ import unittest
 from pathlib import Path
 from unittest.mock import patch
 
-
 SCRIPT_PATH = (
     Path(__file__).resolve().parent.parent / "scripts" / "refresh-flake-inputs"
 )
@@ -29,16 +28,20 @@ def load_script_module():
 
 class RunRefreshTest(unittest.TestCase):
     def test_loader_error_is_not_skipped_under_optimized_python(self):
-        with patch.object(
-            importlib.util,
-            "spec_from_loader",
-            return_value=importlib.machinery.ModuleSpec("refresh_flake_inputs", None),
-        ):
-            with self.assertRaisesRegex(
+        with (
+            patch.object(
+                importlib.util,
+                "spec_from_loader",
+                return_value=importlib.machinery.ModuleSpec(
+                    "refresh_flake_inputs", None
+                ),
+            ),
+            self.assertRaisesRegex(
                 RuntimeError,
                 "Unable to load refresh-flake-inputs script",
-            ):
-                load_script_module()
+            ),
+        ):
+            load_script_module()
 
     def test_runs_multiple_hash_fix_passes_until_build_succeeds(self):
         module = load_script_module()
@@ -127,17 +130,17 @@ class RunRefreshTest(unittest.TestCase):
             patch.object(module.subprocess, "run", side_effect=fake_build),
             patch.object(module, "run", side_effect=fake_run),
             patch.object(module, "run_hash_fixer", return_value=None),
-        ):
-            with self.assertRaisesRegex(
+            self.assertRaisesRegex(
                 SystemExit,
                 "Build still fails and hash fixer made no changes",
-            ):
-                module.run_refresh(
-                    cwd=Path("/repo"),
-                    selected=["nixpkgs"],
-                    build_target=".#homeConfigurations.coneill.activationPackage",
-                    fix_hashes_command="determinate-nixd fix hashes --auto-apply",
-                )
+            ),
+        ):
+            module.run_refresh(
+                cwd=Path("/repo"),
+                selected=["nixpkgs"],
+                build_target=".#homeConfigurations.coneill.activationPackage",
+                fix_hashes_command="determinate-nixd fix hashes --auto-apply",
+            )
 
         self.assertEqual(1, build_count)
 
@@ -305,10 +308,8 @@ class FlakeReleasePackagingTest(unittest.TestCase):
 
         expected_assets = {
             "aarch64-darwin": "macos-arm64",
-            "aarch64-linux": "linux-arm64",
-            "x86_64-linux": "linux-x86_64",
         }
-        self.assertEqual(3, len(memex_records))
+        self.assertEqual(1, len(memex_records))
         self.assertEqual(
             set(expected_assets), {record["attrPath"][1] for record in memex_records}
         )


### PR DESCRIPTION
Memex needs a reproducible CPU-backed installation and continuous index service instead of split Homebrew and manual service management. Package the official release binaries with fixed hashes, configure Home Manager and launchd, and connect releases to the existing Renovate hash-refresh and cross-platform cache workflows.
