### PR TITLE
Allow Codex to write the GitHub CLI cache

### DIFF
--- a/scripts/cco-claude
+++ b/scripts/cco-claude
@@ -38,6 +38,7 @@ case "$name" in
     export OPENCODE_ENABLE_EXA=1
     ;;
   cco-codex)
+    cco_args+=(--add-dir ~/.cache/gh:rw)
     mode_args=(codex --dangerously-bypass-approvals-and-sandbox)
     ;;
   *)


### PR DESCRIPTION
GitHub CLI operations inside the CCO Codex sandbox need access to its cache directory. Grant read-write access only for the Codex wrapper so the other wrappers retain their existing permissions.
